### PR TITLE
docs: Explicitly add root dir to autodoc path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,10 +11,10 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
Previously, the installed ndscan package (if any) would have
been picked up by autodoc instead of the local source files.