### PR TITLE
docs: Switch to rtd Sphinx theme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 artiq-docker: &artiq_docker
     docker:
-      - image: dnadlinger/docker-oitg-artiq@sha256:6f80fca9945a522500ce9e30a9cc3c1b28745d6000ac88502cf18c4c5dbf8da1
+      - image: dnadlinger/docker-oitg-artiq@sha256:27c0a5250439081213511d76276c27bfeaf47d299818355f1418438a4d1b0862
 
     # The container is set up such that the correct Conda environment gets
     # activated in ~/.bashrc, but CircleCI seems to override it when not

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,14 +75,24 @@ pygments_style = None
 
 # -- Options for HTML output -------------------------------------------------
 
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
-html_theme_options = {}
+html_theme_options = {
+    'canonical_url': 'https://oxfordiontrapgroup.github.io/ndscan/',
+}
+
+html_context = {
+    'display_github': True,
+    'github_user': 'OxfordIonTrapGroup',
+    'github_repo': 'ndscan',
+    'github_version': 'master',
+    'conf_py_path': '/docs/'
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
None of the themes I tried handle type annotations well, but
Alabaster displays them particularly poorly.

Also configures "Edit on GitHub" links.