### PR TITLE
experiment: Use shortened paths as create_and_run_fragment_once result keys

### DIFF
--- a/ndscan/utils.py
+++ b/ndscan/utils.py
@@ -1,5 +1,5 @@
 from artiq.language import units
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, Iterable, List
 
 
 def path_matches_spec(path: List[str], spec: str) -> bool:
@@ -26,7 +26,8 @@ def is_kernel(func) -> bool:
 
 
 def shorten_to_unambiguous_suffixes(
-        fqns: List[str], get_last_n_parts: Callable[[str, int], str]) -> Dict[str, str]:
+        fqns: Iterable[str],
+        get_last_n_parts: Callable[[str, int], str]) -> Dict[str, str]:
     short_to_fqns = dict()
     shortened_fqns = dict()
 

--- a/test/test_experiment.py
+++ b/test/test_experiment.py
@@ -3,7 +3,9 @@ Tests for ndscan.experiment top-level runners.
 """
 
 import json
-from ndscan.experiment import make_fragment_scan_exp, run_fragment_once
+from artiq.language import HasEnvironment
+from ndscan.experiment import (make_fragment_scan_exp, run_fragment_once,
+                               create_and_run_fragment_once)
 from fixtures import AddOneFragment, ReboundAddOneFragment, TrivialKernelFragment
 from mock_environment import HasEnvironmentCase
 
@@ -83,3 +85,8 @@ class RunOnceCase(HasEnvironmentCase):
         fragment = self.create(TrivialKernelFragment, [])
         run_fragment_once(fragment)
         self.assertEqual(self.core.run.call_count, 1)
+
+    def test_create_and_run_once(self):
+        self.assertEqual(
+            create_and_run_fragment_once(self.create(HasEnvironment), AddOneFragment),
+            {"result": 1.0})


### PR DESCRIPTION
The ExpFragment instance is internal to the function, so using the ResultChannel
instances as keys isn't very helpful.