### PR TITLE
Simplify auto_fit spec result name handling

### DIFF
--- a/ndscan/auto_fit.py
+++ b/ndscan/auto_fit.py
@@ -87,7 +87,7 @@ class AutoFitSpec:
         return True
 
     def describe(self, get_axis_name: Callable[[Tuple[str, str]], str],
-                 get_channel_name: Callable[[str], str]) -> Dict[str, Any]:
+                 get_channel_name: Callable[[ResultChannel], str]) -> Dict[str, Any]:
         """Serialise information about this fit to stringly typed metadata.
 
         :param get_axis_name: Callable to resolve axis identity to the string to use
@@ -102,7 +102,7 @@ class AutoFitSpec:
             if isinstance(obj, ParamHandle):
                 return get_axis_name(obj._store.identity)
             elif isinstance(obj, ResultChannel):
-                return get_channel_name(obj.path)
+                return get_channel_name(obj)
             else:
                 raise ValueError("Invalid fit argument source: {}".format(obj))
 

--- a/ndscan/experiment.py
+++ b/ndscan/experiment.py
@@ -132,20 +132,16 @@ class FragmentScanExperiment(EnvExperiment):
 
         chan_name_map = _shorten_result_channel_names(chan_dict.keys())
 
-        self.channels = {}
-        self._channel_dataset_names = {}
+        self._short_child_channel_names = {}
         for path, channel in chan_dict.items():
             if not channel.save_by_default:
                 continue
             name = chan_name_map[path].replace("/", "_")
-            self.channels[name] = channel
+            self._short_child_channel_names[channel] = name
 
             if self._scan.axes:
-                dataset = "channel_{}".format(name)
-                self._channel_dataset_names[path] = dataset
-                sink = AppendingDatasetSink(self, "ndscan.points." + dataset)
+                sink = AppendingDatasetSink(self, "ndscan.points.channel_" + name)
             else:
-                self._channel_dataset_names[path] = name
                 sink = ScalarDatasetSink(self, "ndscan.point." + name)
             channel.set_sink(sink)
 
@@ -212,8 +208,8 @@ class FragmentScanExperiment(EnvExperiment):
         push("rid", self.scheduler.rid)
         push("completed", False)
 
-        scan_desc = describe_scan(self._scan, self.fragment, self.channels,
-                                  self._channel_dataset_names)
+        scan_desc = describe_scan(self._scan, self.fragment,
+                                  self._short_child_channel_names)
 
         # KLDUGE: Broadcast auto_fit before channels to allow simpler implementation
         # in current fit applet. As the applet implementation grows more sophisticated

--- a/ndscan/scan_runner.py
+++ b/ndscan/scan_runner.py
@@ -207,15 +207,12 @@ class ScanRunner(HasEnvironment):
 
 
 def describe_scan(spec: ScanSpec, fragment: ExpFragment,
-                  results_by_short_name: Dict[str, ResultChannel],
-                  result_key_names_by_path: Dict[str, str]):
+                  short_result_names: Dict[ResultChannel, str]):
     """Return metadata for the given spec in stringly typed dictionary form.
 
     :param spec: :class:`ScanSpec` describing the scan.
     :param fragment: Fragment being scanned.
-    :param results_by_short_name: Map from short result names to channel objects.
-    :param result_key_names_by_path: Map from result channel path to name of result key
-        ("channel_…").
+    :param short_result_names: Map from result channel objects to shortened names.
     """
     desc = {}
 
@@ -231,7 +228,7 @@ def describe_scan(spec: ScanSpec, fragment: ExpFragment,
     desc["seed"] = spec.options.seed
     desc["channels"] = {
         name: channel.describe()
-        for (name, channel) in results_by_short_name.items()
+        for (channel, name) in short_result_names.items()
     }
 
     desc["auto_fit"] = []
@@ -241,6 +238,6 @@ def describe_scan(spec: ScanSpec, fragment: ExpFragment,
             desc["auto_fit"].append(
                 f.describe(
                     lambda identity: "axis_{}".format(axis_identities.index(identity)),
-                    lambda path: result_key_names_by_path[path]))
+                    lambda channel: "channel_" + short_result_names[channel]))
 
     return desc


### PR DESCRIPTION
For continuous scans, there would have been no way for auto-fits to
reference any parameters, so FragmentScanExperiment._channel_dataset_names
was an unnecessary abstraction.