### PR TITLE
default_analysis: Do away with axis string names in CustomAnalysis

### DIFF
--- a/examples/rabi_flop_custom_analysis.py
+++ b/examples/rabi_flop_custom_analysis.py
@@ -11,10 +11,10 @@ class RabiFlopWithAnalysis(RabiFlopSim):
     """
 
     def get_default_analyses(self):
-        return [CustomAnalysis({"t": self.duration}, self._analyse_time_scan)]
+        return [CustomAnalysis([self.duration], self._analyse_time_scan)]
 
     def _analyse_time_scan(self, axis_values, result_values):
-        x = axis_values["t"]
+        x = axis_values[self.duration]
         y = result_values[self.readout.p]
         y_err = result_values[self.readout.p_err]
         fit_results, fit_errs, fit_xs, fit_ys, = oitg.fitting.rabi_flop.fit(

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -47,11 +47,11 @@ class ReboundAddOneFragment(ExpFragment):
 
 class AddOneCustomAnalysisFragment(AddOneFragment):
     def get_default_analyses(self):
-        return [CustomAnalysis({"x": self.value}, self._analyze)]
+        return [CustomAnalysis({self.value}, self._analyze)]
 
     def _analyze(self, axis_values, result_values):
         return [
-            Annotation("location", {self.value: numpy.mean(axis_values["x"])}),
+            Annotation("location", {self.value: numpy.mean(axis_values[self.value])}),
             Annotation("location",
                        {self.result: numpy.mean(result_values[self.result])})
         ]


### PR DESCRIPTION
The names didn't actually make the API any more widely applicable, as
even for wildcard scans, the user can always access the respective
handles directly, and we will match the references using the store
identities internally.