### PR TITLE
plots: Use full path for associating error bars to channels

### DIFF
--- a/examples/rabi_flop.py
+++ b/examples/rabi_flop.py
@@ -19,10 +19,10 @@ class Readout(Fragment):
 
         self.setattr_result("counts", OpaqueChannel)
         self.setattr_result("p")
-        self.setattr_result("p_err", display_hints={"error_bar_for": "p"})
+        self.setattr_result("p_err", display_hints={"error_bar_for": self.p.path})
 
         self.setattr_result("z")
-        self.setattr_result("z_err", display_hints={"error_bar_for": "z"})
+        self.setattr_result("z_err", display_hints={"error_bar_for": self.z.path})
 
         self.setattr_result("half", display_hints={"priority": -1})
 

--- a/examples/rabi_flop_pi_time_fit.py
+++ b/examples/rabi_flop_pi_time_fit.py
@@ -11,7 +11,7 @@ class PiTimeFitSim(ExpFragment):
         self.setattr_fragment("flop", RabiFlopSim)
         setattr_subscan(self, "scan", self.flop, [(self.flop, "duration")])
         self.setattr_result("t_pi", unit="us")
-        self.setattr_result("t_pi_err", display_hints={"error_bar_for": "t_pi"})
+        self.setattr_result("t_pi_err", display_hints={"error_bar_for": self.t_pi.path})
         # self.scan.add_annotation()
 
     def run_once(self):


### PR DESCRIPTION
The previous implementation worked out of sheer luck if only a single
channel with each name existed.