### PR TITLE
default_analysis: Execute online fits only if the axes exactly match

### DIFF
--- a/ndscan/default_analysis.py
+++ b/ndscan/default_analysis.py
@@ -213,13 +213,15 @@ class OnlineFit(DefaultAnalysis):
         self.analysis_identifier = analysis_identifier
 
     def has_data(self, scanned_axes: List[Tuple[str, str]]):
+        num_axes = 0
         for arg in self.data.values():
             if isinstance(arg, ParamHandle):
+                num_axes += 1
                 if not arg._store:
                     return False
                 if arg._store.identity not in scanned_axes:
                     return False
-        return True
+        return len(scanned_axes) == num_axes
 
     def describe_online_analyses(
             self, context: AnnotationContext


### PR DESCRIPTION
Previously, fits would also be created if there were additional scan
dimensions, which is almost never what one wants.