### PR TITLE
default_analysis: Specify associated channel for online fit location annotations

### DIFF
--- a/ndscan/default_analysis.py
+++ b/ndscan/default_analysis.py
@@ -263,7 +263,8 @@ class OnlineFit(DefaultAnalysis):
                         data={
                             context.describe_coordinate(self.data["x"]) + "_error":
                             analysis_ref(a["x"] + "_error")
-                        }))
+                        },
+                        parameters={"associated_channels": channels}))
 
         return [a.describe(context) for a in annotations], {
             analysis_identifier: {

--- a/test/test_experiment.py
+++ b/test/test_experiment.py
@@ -63,7 +63,9 @@ class FragmentScanExpCase(HasEnvironmentCase):
         }
         location_annotation = {
             "kind": "location",
-            "parameters": {},
+            "parameters": {
+                "associated_channels": ["channel_result"]
+            },
             "coordinates": {
                 "axis_0": {
                     "analysis_name": "fit_lorentzian_channel_result",

--- a/test/test_subscan.py
+++ b/test/test_subscan.py
@@ -85,7 +85,9 @@ class SubscanCase(ExpFragmentCase):
         }
         location_annotation = {
             "kind": "location",
-            "parameters": {},
+            "parameters": {
+                "associated_channels": ["channel_result"]
+            },
             "coordinates": {
                 "axis_0": {
                     "analysis_name": "fit_lorentzian_channel_result",


### PR DESCRIPTION
This way, they will be displayed along with the right channels in the UI
(regarding color, etc.).