### PR TITLE
experiment: Provide sensible error message when double-rebinding

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -253,6 +253,11 @@ class Fragment(HasEnvironment):
 
         if original_name is None:
             original_name = name
+        assert hasattr(original_owner, original_name), \
+            "Original owner does not have a field of name '{}'".format(original_name)
+        assert original_name in original_owner._free_params, (
+            "Field '{}' is not a free parameter of original owner; "
+            "already rebound?".format(original_name))
 
         # Set up our own copy of the parameter.
         original_param = original_owner._free_params[original_name]


### PR DESCRIPTION
This previously just threw a KeyError trying to access _free_params,
which is not exactly user-friendly.