### PR TITLE
CI: Try automatically rebasing to-be-auto-merged branches

### DIFF
--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -4,3 +4,6 @@ merge:
     labels: ["auto-merge"]
   method: rebase
   delete_after_merge: true
+update:
+  whitelist:
+    labels: ["auto-merge"]


### PR DESCRIPTION
This should help the case where there are multiple non-conflicting
auto-merge PRs in the queue, which currently need to be manually
rebased onto master before they are mergerd.