### PR TITLE
plots: Fix multiple y axes for subscans

### DIFF
--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -52,6 +52,13 @@ class MultiYAxisPlotWidget(pyqtgraph.PlotWidget):
         self._update_additional_view_boxes()
         return axis, vb
 
+    def reset_y_axes(self):
+        # TODO: Do we need to unlink anything else to avoid leaking memory?
+        for vb in self._additional_view_boxes:
+            self.getPlotItem().removeItem(vb)
+        self._additional_view_boxes = []
+        self._num_y_axes = 0
+
     def _update_additional_view_boxes(self):
         for vb in self._additional_view_boxes:
             vb.setGeometry(self.getViewBox().sceneBoundingRect())

--- a/ndscan/plots/rolling_1d.py
+++ b/ndscan/plots/rolling_1d.py
@@ -86,6 +86,7 @@ class Rolling1DPlotWidget(AlternateMenuPlotWidget):
         for s in self.series:
             s.remove_items()
         self.series.clear()
+        self.reset_y_axes()
 
         channels = self.model.get_channel_schemata()
         try:

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -126,6 +126,7 @@ class XY1DPlotWidget(SubplotMenuPlotWidget):
         for s in self.series:
             s.remove_items()
         self.series.clear()
+        self.reset_y_axes()
 
         try:
             data_names, error_bar_names = extract_scalar_channels(channels)


### PR DESCRIPTION
The same plot widget is reused multiple time for subscan plots,
so we need to remove any extra y axes that were added before.