### PR TITLE
examples: Use sinusoid fit in place of rabi_flop

### DIFF
--- a/examples/rabi_flop.py
+++ b/examples/rabi_flop.py
@@ -55,12 +55,14 @@ class RabiFlopSim(ExpFragment):
                            FloatParam,
                            "Rabi frequency",
                            1.0 * MHz,
-                           unit="MHz")
+                           unit="MHz",
+                           min=0.0)
         self.setattr_param("duration",
                            FloatParam,
                            "Pulse duration",
                            0.5 * us,
-                           unit="us")
+                           unit="us",
+                           min=0.0)
         self.setattr_param("detuning", FloatParam, "Detuning", 0.0 * MHz, unit="MHz")
 
     def run_once(self):

--- a/examples/rabi_flop.py
+++ b/examples/rabi_flop.py
@@ -73,11 +73,15 @@ class RabiFlopSim(ExpFragment):
 
     def get_default_analyses(self):
         return [
-            OnlineFit("rabi_flop", {
-                "x": self.duration,
-                "y": self.readout.p,
-                "y_err": self.readout.p_err
-            }),
+            OnlineFit("sinusoid",
+                      data={
+                          "x": self.duration,
+                          "y": self.readout.p,
+                          "y_err": self.readout.p_err,
+                      },
+                      constants={
+                          "t_dead": 0,
+                      }),
             OnlineFit("cos", {
                 "x": self.duration,
                 "y": self.readout.z,

--- a/examples/rabi_flop_custom_analysis.py
+++ b/examples/rabi_flop_custom_analysis.py
@@ -15,7 +15,7 @@ class RabiFlopWithAnalysis(RabiFlopSim):
         x = axis_values[self.duration]
         y = result_values[self.readout.p]
         y_err = result_values[self.readout.p_err]
-        fit_results, fit_errs, fit_xs, fit_ys, = oitg.fitting.rabi_flop.fit(
+        fit_results, fit_errs, fit_xs, fit_ys, = oitg.fitting.sinusoid.fit(
             x, y, y_err, evaluate_function=True)
         return [
             Annotation("location", {self.duration: fit_results["t_pi"]}),

--- a/examples/rabi_flop_pi_time_fit.py
+++ b/examples/rabi_flop_pi_time_fit.py
@@ -16,7 +16,7 @@ class PiTimeFitSim(ExpFragment):
         x = coords[self.flop.duration]
         y = points[self.flop.readout.p]
         y_err = points[self.flop.readout.p_err]
-        fit_results, fit_errs = oitg.fitting.rabi_flop.fit(x, y, y_err)
+        fit_results, fit_errs = oitg.fitting.sinusoid.fit(x, y, y_err)
         self.t_pi.push(fit_results["t_pi"])
         self.t_pi_err.push(fit_errs["t_pi"])
 


### PR DESCRIPTION
`rabi_flop` will go the way of the dodo.