### PR TITLE
experiment: Do no execute host_setup() every time for on-host scans

### DIFF
--- a/test/test_experiment_entrypoint.py
+++ b/test/test_experiment_entrypoint.py
@@ -34,10 +34,10 @@ class FragmentScanExpCase(HasEnvironmentCase):
 
     def test_run_1d_scan(self):
         exp = self._test_run_1d(ScanAddOneExp, "fixtures.AddOneFragment")
-        self.assertEqual(exp.fragment.num_host_setup_calls, 3)
+        self.assertEqual(exp.fragment.num_host_setup_calls, 1)
         self.assertEqual(exp.fragment.num_device_setup_calls, 3)
-        self.assertEqual(exp.fragment.num_host_cleanup_calls, 3)
-        self.assertEqual(exp.fragment.num_device_cleanup_calls, 3)
+        self.assertEqual(exp.fragment.num_host_cleanup_calls, 1)
+        self.assertEqual(exp.fragment.num_device_cleanup_calls, 1)
 
         curve_annotation = {
             "kind": "computed_curve",
@@ -112,10 +112,10 @@ class FragmentScanExpCase(HasEnvironmentCase):
 
     def test_run_rebound_1d_scan(self):
         exp = self._test_run_1d(ScanReboundAddOneExp, "fixtures.ReboundAddOneFragment")
-        self.assertEqual(exp.fragment.add_one.num_host_setup_calls, 3)
+        self.assertEqual(exp.fragment.add_one.num_host_setup_calls, 1)
         self.assertEqual(exp.fragment.add_one.num_device_setup_calls, 3)
-        self.assertEqual(exp.fragment.add_one.num_host_cleanup_calls, 3)
-        self.assertEqual(exp.fragment.add_one.num_device_cleanup_calls, 3)
+        self.assertEqual(exp.fragment.add_one.num_host_cleanup_calls, 1)
+        self.assertEqual(exp.fragment.add_one.num_device_cleanup_calls, 1)
 
     def _test_run_1d(self, klass, fragment_fqn):
         exp = self.create(klass)


### PR DESCRIPTION
This changes the behaviour of scans executed on the host such that
host_setup() is only called once (and after the experiment has been
interrupted) instead of before every scan point. This more closely
matches the behaviour that users might expect from kernel-based scans,
but has he disadvantage that the current lack of the planned
implementation of host-only parameters (i.e. fragments that require
host_setup() to be run for changes to take effect, such as magnetic
field servos) cannot be worked around anymore by just running the
scan from a non-kernel-run_once() fragment.

cc @pathfinder49 @AUTProgram