### PR TITLE
utils: Fix shorten_to_unambiguous_suffixes()

### DIFF
--- a/ndscan/utils.py
+++ b/ndscan/utils.py
@@ -58,7 +58,7 @@ def shorten_to_unambiguous_suffixes(fqns: Iterable[str],
         while True:
             candidate = get_last_n_parts(current, n)
             if candidate not in short_to_fqns:
-                short_to_fqns[candidate] = set([current])
+                short_to_fqns[candidate] = {current}
                 shortened_fqns[current] = candidate
                 break
 
@@ -68,7 +68,9 @@ def shorten_to_unambiguous_suffixes(fqns: Iterable[str],
                 if shortened_fqns[old] == candidate:
                     # This hasn't previously been moved to a higher n, so
                     # do it now.
-                    shortened_fqns[old] = get_last_n_parts(old, n + 1)
+                    new = get_last_n_parts(old, n + 1)
+                    shortened_fqns[old] = new
+                    short_to_fqns[new] = {old}
                     break  # Exits inner for loop.
             existing_fqns.add(current)
             n += 1

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -22,3 +22,8 @@ class ShortenTest(unittest.TestCase):
 
         test({"foo": "foo"})
         test({"": "", "foo/bar": "foo/bar", "foo/baz": "baz", "baz/bar": "baz/bar"})
+
+        test({"a1/b": "a1/b", "a2/b": "a2/b"})
+        test({"a1/b/c": "a1/b/c", "a2/b/c": "a2/b/c"})
+        test({"a1/b/c/d": "a1/b/c/d", "a2/b/c/d": "a2/b/c/d"})
+        test({"a1/b/c/d/e": "a1/b/c/d/e", "a2/b/c/d/e": "a2/b/c/d/e"})


### PR DESCRIPTION
Previously, the case where more then one level would need to be
added to disambiguate was not tested, and was in fact broken.

(The only actual change is the added assignment to short_to_fqns.)