### PR TITLE
experiment: Don't use reference type default parameter

### DIFF
--- a/ndscan/experiment/default_analysis.py
+++ b/ndscan/experiment/default_analysis.py
@@ -3,7 +3,7 @@ Declarative fits, to be excecuted locally by the user interface displaying the d
 it comes in.
 """
 import logging
-from typing import Any, Callable, Dict, List, Iterable, Tuple, Union
+from typing import Any, Callable, Dict, List, Iterable, Optional, Tuple, Union
 
 from ..utils import FIT_OBJECTS
 from .parameters import ParamHandle
@@ -52,13 +52,13 @@ class Annotation:
     """
     def __init__(self,
                  kind: str,
-                 coordinates: dict = {},
-                 parameters: dict = {},
-                 data: dict = {}):
+                 coordinates: Optional[dict] = None,
+                 parameters: Optional[dict] = None,
+                 data: Optional[dict] = None):
         self.kind = kind
-        self.coordinates = coordinates
-        self.parameters = parameters
-        self.data = data
+        self.coordinates = {} if coordinates is None else coordinates
+        self.parameters = {} if parameters is None else parameters
+        self.data = {} if data is None else data
 
     def describe(self, context: AnnotationContext) -> Dict[str, Any]:
         def to_spec_map(dictionary):
@@ -230,8 +230,8 @@ class OnlineFit(DefaultAnalysis):
                  data: Dict[str, Union[ParamHandle, ResultChannel]],
                  annotations: Union[None, Dict[str, Dict[str, Any]]] = None,
                  analysis_identifier: str = None,
-                 constants: Dict[str, Any] = {},
-                 initial_values: Dict[str, Any] = {}):
+                 constants: Optional[Dict[str, Any]] = None,
+                 initial_values: Optional[Dict[str, Any]] = None):
         self.fit_type = fit_type
         if fit_type not in FIT_OBJECTS:
             logger.warning("Unknown fit type: '%s'", fit_type, exc_info=True)
@@ -240,8 +240,8 @@ class OnlineFit(DefaultAnalysis):
             annotations = DEFAULT_FIT_ANNOTATIONS.get(fit_type, {})
         self.annotations = annotations
         self.analysis_identifier = analysis_identifier
-        self.constants = constants
-        self.initial_values = initial_values
+        self.constants = {} if constants is None else constants
+        self.initial_values = {} if initial_values is None else initial_values
 
     def has_data(self, scanned_axes: List[Tuple[str, str]]):
         ""

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -5,7 +5,7 @@ Result handling building blocks.
 from artiq.language import HasEnvironment, rpc
 import artiq.language.units
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 __all__ = [
     "LastValueSink", "ArraySink", "AppendingDatasetSink", "ScalarDatasetSink",
@@ -100,11 +100,11 @@ class ResultChannel:
     def __init__(self,
                  path: str,
                  description: str = "",
-                 display_hints: Dict[str, Any] = {},
+                 display_hints: Optional[Dict[str, Any]] = None,
                  save_by_default: bool = True):
         self.path = path
         self.description = description
-        self.display_hints = display_hints
+        self.display_hints = {} if display_hints is None else display_hints
         self.save_by_default = save_by_default
         self.sink = None
 
@@ -156,7 +156,7 @@ class NumericChannel(ResultChannel):
     def __init__(self,
                  path: str,
                  description: str = "",
-                 display_hints: Dict[str, Any] = {},
+                 display_hints: Optional[Dict[str, Any]] = None,
                  min=None,
                  max=None,
                  unit: str = "",

--- a/test/test_plots_schema_handling.py
+++ b/test/test_plots_schema_handling.py
@@ -31,6 +31,11 @@ class TestFragment(ExpFragment):
         self.setattr_fragment("n0", NestedFragment)
         self.setattr_fragment("n1", NestedFragment)
 
+        # Also try manually adding display hints to channels from subfragments.
+        self.setattr_fragment("n2", NestedFragment)
+        self.setattr_fragment("n3", NestedFragment)
+        self.n3.g.display_hints["share_axis_with"] = self.n2.g.path
+
 
 TestExp = make_fragment_scan_exp(TestFragment)
 
@@ -44,10 +49,12 @@ class FragmentScanExpCase(HasEnvironmentCase):
         channels = json.loads(self.dataset_db.get("ndscan.channels"))
 
         data_names, error_bar_names = extract_scalar_channels(channels)
-        self.assertEqual(data_names,
-                         ["b", "a", "d", "e", "f", "n0_g", "n0_h", "n1_g", "n1_h"])
+        self.assertEqual(data_names, [
+            "b", "a", "d", "e", "f", "n0_g", "n0_h", "n1_g", "n1_h", "n2_g", "n2_h",
+            "n3_g", "n3_h"
+        ])
         self.assertEqual(error_bar_names, {"a": "a_err"})
 
         groups = group_channels_into_axes(channels, data_names)
-        self.assertEqual(
-            groups, [["b", "f"], ["a", "d", "e"], ["n0_g", "n0_h"], ["n1_g", "n1_h"]])
+        self.assertEqual(groups, [["b", "f"], ["a", "d", "e"], ["n0_g", "n0_h"],
+                                  ["n1_g", "n1_h"], ["n2_g", "n2_h", "n3_g", "n3_h"]])


### PR DESCRIPTION
Since Python doesn't "syntactically" copy default parameters into the
caller's function invocation, but saves references that are later
evaluated, passing "reference types" (e.g. arrays, dicts, …) as default
parameters can lead to unintended results if the callee modifies them
(all invocations share a reference to the same object).