### PR TITLE
experiment: "Ignore" -> "Catch" for transitory error messages [nfc]

### DIFF
--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -392,14 +392,14 @@ class _FragmentRunner(HasEnvironment):
                     if (self.num_transitory_errors_caught >
                             self.max_transitory_error_retries):
                         raise
-                    print("Ignoring transitory error, restarting kernel")
+                    print("Caught transitory error, restarting kernel")
                     return False
                 except TransitoryError:
                     self.num_transitory_errors_caught += 1
                     if (self.num_transitory_errors_caught >
                             self.max_transitory_error_retries):
                         raise
-                    print("Ignoring transitory error (",
+                    print("Caught transitory error (",
                           self.num_transitory_errors_caught, "/",
                           self.max_transitory_error_retries, "), retrying")
         finally:

--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -237,14 +237,14 @@ class ScanRunner(HasEnvironment):
                       NUM_TOLERATED_UNDERFLOWS_PER_POINT, ")")
                 self._kscan_retry_point()
             except RestartKernelTransitoryError:
-                print("Ignoring transitory error, restarting kernel")
+                print("Caught transitory error, restarting kernel")
                 self._kscan_retry_point()
                 return True
             except TransitoryError:
                 if num_transitory_errors >= NUM_TOLERATED_TRANSITORY_ERRORS_PER_POINT:
                     raise
                 num_transitory_errors += 1
-                print("Ignoring transitory error (", num_transitory_errors, "/",
+                print("Caught transitory error (", num_transitory_errors, "/",
                       NUM_TOLERATED_TRANSITORY_ERRORS_PER_POINT, "), retrying")
                 self._kscan_retry_point()
         self._kscan_point_completed()


### PR DESCRIPTION
They are not ignored, since being caught this way is their only purpose.