### PR TITLE
plots: Make single-point scans robust

### DIFF
--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -241,6 +241,7 @@ class FragmentScanExperiment(EnvExperiment):
                 while True:
                     try:
                         self.fragment.host_setup()
+                        self._point_phase = False
                         if is_kernel(self.fragment.run_once):
                             self._run_continuous_kernel()
                             self.core.comm.close()
@@ -273,6 +274,8 @@ class FragmentScanExperiment(EnvExperiment):
 
     @rpc(flags={"async"})
     def _finish_continuous_point(self):
+        self._point_phase = not self._point_phase
+        self.set_dataset("ndscan.point_phase", self._point_phase, broadcast=True)
         if self._is_time_series:
             self._timestamp_sink.push(time.monotonic() - self._time_series_start)
 

--- a/test/test_plots_model_subscriber.py
+++ b/test/test_plots_model_subscriber.py
@@ -1,0 +1,108 @@
+import json
+import unittest
+
+from sipyco.sync_struct import Notifier
+
+from ndscan.plots.model import Context
+from ndscan.plots.model.subscriber import SubscriberRoot
+
+
+class SinglePointTest(unittest.TestCase):
+    def setUp(self):
+        self.context = Context()
+        self.root = SubscriberRoot(self.context)
+        self.datasets = Notifier({
+            "ndscan.axes": (False, "[]"),
+            "ndscan.channels": (False,
+                                json.dumps({
+                                    "foo": {
+                                        "description": "Foo",
+                                        "path": "foo",
+                                        "type": "int",
+                                        "unit": ""
+                                    },
+                                    "bar": {
+                                        "description": "Bar",
+                                        "path": "foo",
+                                        "type": "int",
+                                        "unit": ""
+                                    }
+                                }))
+        })
+        self.pending_mods = []
+        self.datasets.publish = lambda a: self.pending_mods.append(a)
+
+    def init(self):
+        self.pending_mods = [{
+            "action": "init",
+            "struct": self.datasets.raw_view.copy()
+        }]
+        self.sync()
+
+    def sync(self):
+        self.root.data_changed(self.datasets.raw_view, self.pending_mods)
+        self.pending_mods.clear()
+
+    def test_new_point(self):
+        self.init()
+        self.datasets["ndscan.point.foo"] = (False, 42)
+        self.datasets["ndscan.point.bar"] = (False, 23)
+        self.datasets["ndscan.point_phase"] = (False, True)
+        self.sync()
+        self.assertEqual(self.root.get_model().get_point(), {"foo": 42, "bar": 23})
+
+    def test_halfway(self):
+        self.datasets["ndscan.point.foo"] = (False, 42)
+        self.init()
+
+        with self.assertRaises(ValueError):
+            # No complete point yet.
+            self.root.get_model().get_point()
+
+        self.datasets["ndscan.point.bar"] = (False, 23)
+        self.datasets["ndscan.point_phase"] = (False, True)
+        self.sync()
+        self.assertEqual(self.root.get_model().get_point(), {"foo": 42, "bar": 23})
+
+    def test_one_and_a_half(self):
+        self.datasets["ndscan.point.foo"] = (False, 42)
+        self.init()
+
+        with self.assertRaises(ValueError):
+            # No complete point yet.
+            self.root.get_model().get_point()
+
+        self.datasets["ndscan.point.bar"] = (False, 23)
+        self.datasets["ndscan.point_phase"] = (False, True)
+
+        # Already write foo value of next point.
+        self.datasets["ndscan.point.foo"] = (False, 0)
+        self.sync()
+
+        # Foo should still be the old value.
+        self.assertEqual(self.root.get_model().get_point(), {"foo": 42, "bar": 23})
+
+    def test_preexisting(self):
+        self.datasets["ndscan.point.foo"] = (False, 42)
+        self.datasets["ndscan.point.bar"] = (False, 42)
+        self.datasets["ndscan.point_phase"] = (False, True)
+        self.datasets["ndscan.point.foo"] = (False, 0)
+        self.init()
+
+        with self.assertRaises(ValueError):
+            # Can't know whether point is complete (it indeed isn't).
+            self.root.get_model().get_point()
+
+        self.datasets["ndscan.point.bar"] = (False, 1)
+        self.datasets["ndscan.point_phase"] = (False, False)
+        self.sync()
+
+        self.assertEqual(self.root.get_model().get_point(), {"foo": 0, "bar": 1})
+
+    def test_already_completed(self):
+        self.datasets["ndscan.point.foo"] = (False, 42)
+        self.datasets["ndscan.point.bar"] = (False, 23)
+        self.datasets["ndscan.point_phase"] = (False, True)
+        self.datasets["ndscan.completed"] = (False, True)
+        self.init()
+        self.assertEqual(self.root.get_model().get_point(), {"foo": 42, "bar": 23})


### PR DESCRIPTION
Previously, single-point (Single/Repeat) plots relied on not being
launched in the middle of a point update, and the first (only) point
could be missed for Single scans. This wasn't an issue for us so far,
as kernel compilation times usually trumped applet startup times.

This reverts 60d205bbf549f7e9a7dd26a3664132b432d81b87 as well, i.e.
adds back point_phase, as otherwise there is no guarantee about the
order in which individual points are pushed. (This could be avoided
in the future by buffering the push() results instead, and only
emitting the datasets in a known order once the point is finished.)