### PR TITLE
experiment: Add make_namespaced_identifier()

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -505,6 +505,19 @@ class Fragment(HasEnvironment):
         for s in self._subfragments:
             s.recompute_param_defaults()
 
+    def make_namespaced_identifier(self, name: str) -> str:
+        """Mangle passed name and path to this fragment into a string, such that calls
+        from different fragments give different results for the same name.
+
+        This can, for instance, be useful when naming DMA sequences, or interacting with
+        other kinds of global registries, where multiple fragment instances should not
+        conflict with each other.
+
+        The returned string will consist of characters that are valid Python identifiers
+        and slashes.
+        """
+        return "/".join(self._fragment_path + [name])
+
     def _get_all_handles_for_param(self, name: str) -> List[ParamHandle]:
         return [getattr(self, name)] + self._rebound_subfragment_params.get(name, [])
 

--- a/test/test_experiment_fragment.py
+++ b/test/test_experiment_fragment.py
@@ -4,7 +4,7 @@ Tests for general fragment tree behaviour.
 
 from ndscan.experiment import *
 from ndscan.experiment.parameters import IntParamStore
-from fixtures import ReboundReboundAddOneFragment
+from fixtures import AddOneFragment, ReboundReboundAddOneFragment
 from mock_environment import HasEnvironmentCase
 
 
@@ -50,3 +50,12 @@ class TestRebinding(HasEnvironmentCase):
         rrf.override_param("value", 2)
         result = run_fragment_once(rrf)[rrf.rebound_add_one.add_one.result]
         self.assertEqual(result, 3)
+
+
+class TestMisc(HasEnvironmentCase):
+    def test_namespacing(self):
+        a = self.create(AddOneFragment, ["a"])
+        self.assertEqual(a.make_namespaced_identifier("foo"), "a/foo")
+        self.assertEqual(a.make_namespaced_identifier("foo"), "a/foo")
+        b = self.create(AddOneFragment, ["b", "c", "d"])
+        self.assertEqual(b.make_namespaced_identifier("foo"), "b/c/d/foo")


### PR DESCRIPTION
This should always be used for naming DMA recordings.