### PR TITLE
Split off parameter PYON parsing from scan execution; make dataset root key configurable

### DIFF
--- a/ndscan/applet.py
+++ b/ndscan/applet.py
@@ -24,7 +24,7 @@ class _MainWidget(RootWidget):
 
         # TODO: Consider exposing Context in Root.
         context = Context(self.set_dataset)
-        super().__init__(SubscriberRoot(context), context)
+        super().__init__(SubscriberRoot(args.prefix, context), context)
 
         # Try ensuring a sensible window size on startup (i.e. large enough to show a
         # plot in.
@@ -65,6 +65,10 @@ class NdscanApplet(SimpleApplet):
                                     default=3251,
                                     type=int,
                                     help="TCP port for master control commands")
+        self.argparser.add_argument("--prefix",
+                                    default="ndscan.",
+                                    type=str,
+                                    help="Root of the ndscan dataset tree")
         self.argparser.add_argument("--rid", help="RID of the experiment to plot")
 
     def subscribe(self):

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -156,6 +156,12 @@ class TopLevelRunner(HasEnvironment):
         self.spec = spec
         self.max_rtio_underflow_retries = max_rtio_underflow_retries
         self.max_transitory_error_retries = max_transitory_error_retries
+
+        if dataset_prefix and dataset_prefix[-1] != ".":
+            # Add trailing dot to dataset prefix if not given – the same bare prefix
+            # mushed into all the ndscan datasets isn't what a user with an intact sense
+            # of style would intend.
+            dataset_prefix += "."
         self.dataset_prefix = dataset_prefix
 
         self.setattr_device("ccb")

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -213,6 +213,8 @@ class TopLevelRunner(HasEnvironment):
 
         self.fragment.prepare()
 
+        self._coordinate_data = None
+
     def run(self):
         """Run the (possibly trivial) scan."""
         self._broadcast_metadata()
@@ -248,9 +250,10 @@ class TopLevelRunner(HasEnvironment):
         return self._coordinate_data, self._value_data
 
     def analyze(self):
-        if not self.spec.axes:
-            # Return if there are no scan axes - could allow the time series fake axis
-            # in the future.
+        if self._coordinate_data is None:
+            # Experiment was actually terminated by exception, so there is no data to
+            # analyse – gracefully ignore this to keep FragmentScanExperiment
+            # implementation simple.
             return
 
         analyses = filter_default_analyses(self.fragment, self.spec)

--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -338,8 +338,8 @@ def filter_default_analyses(fragment: ExpFragment,
 
 def describe_scan(spec: ScanSpec, fragment: ExpFragment,
                   short_result_names: Dict[ResultChannel, str]):
-    """Return metadata for the given spec in stringly typed dictionary form, executing
-    any default analyses as necessary.
+    """Return metadata for the given spec in stringly typed dictionary form, including
+    that for any online analyses that apply to it.
 
     :param spec: :class:`.ScanSpec` describing the scan.
     :param fragment: Fragment being scanned.

--- a/test/test_plots_model_subscriber.py
+++ b/test/test_plots_model_subscriber.py
@@ -10,7 +10,7 @@ from ndscan.plots.model.subscriber import SubscriberRoot
 class SinglePointTest(unittest.TestCase):
     def setUp(self):
         self.context = Context()
-        self.root = SubscriberRoot(self.context)
+        self.root = SubscriberRoot("ndscan.", self.context)
         self.datasets = Notifier({
             "ndscan.axes": (False, "[]"),
             "ndscan.channels": (False,


### PR DESCRIPTION
Together, this allows running multiple custom scan as part of an EnvExperiment, for instance a more complex calibration experiment, without resorting to subscans.