### PR TITLE
experiment: Don't issue applets as transient

### DIFF
--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -421,7 +421,7 @@ class TopLevelRunner(HasEnvironment):
         cmd += " --rid={}".format(self.scheduler.rid)
         if self.dataset_prefix != "ndscan.":
             cmd += " --prefix={}".format(self.dataset_prefix)
-        self.ccb.issue("create_applet", title, cmd, group=group, is_transient=True)
+        self.ccb.issue("create_applet", title, cmd, group=group)
 
 
 def _shorten_result_channel_names(full_names: Iterable[str]) -> Dict[str, str]:


### PR DESCRIPTION
The feature has been removed from our ARTIQ branch instead of
upstreaming it.

This commit is backwards-compatible to previous ARTIQ versions;
new Oxford ARTIQ builds will, on the other hand, require this
commit.