### PR TITLE
Fix issue 247: AttributeError in xy_1d.py

### DIFF
--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -31,8 +31,9 @@ class _XYSeries(QtCore.QObject):
 
     def update(self, x_data, data):
         def channel(name):
-            return data.get("channel_" + name, [])
+            return np.array(data.get("channel_" + name, []))
 
+        x_data = np.array(x_data)
         y_data = channel(self.data_name)
         num_to_show = min(len(x_data), len(y_data))
 
@@ -44,16 +45,13 @@ class _XYSeries(QtCore.QObject):
             return
 
         if self.plot_left_to_right:
-            x_data = np.array(x_data)
             order = np.argsort(x_data[:num_to_show])
 
-            y_data = np.array(y_data)
             self.data_item.setData(x_data[order], y_data[order])
             if self.num_current_points == 0:
                 self.view_box.addItem(self.data_item)
 
             if self.error_bar_item:
-                y_err = np.array(y_err)
                 self.error_bar_item.setData(x=x_data[order],
                                             y=y_data[order],
                                             height=y_err[order])
@@ -67,7 +65,7 @@ class _XYSeries(QtCore.QObject):
             if self.error_bar_item:
                 self.error_bar_item.setData(x=x_data[:num_to_show],
                                             y=y_data[:num_to_show],
-                                            height=(2 * np.array(y_err[:num_to_show])))
+                                            height=(2 * y_err[:num_to_show]))
                 if self.num_current_points == 0:
                     self.view_box.addItem(self.error_bar_item)
 


### PR DESCRIPTION
PyQtGraph's ErrorBarItem's setData method requires numpy arrays, but
ndscan was passing in lists, causing an AttributeError when the size
method was called.

Looking at PyQtGraph's history, the documentation has specified this since the `setData` method was added https://github.com/pyqtgraph/pyqtgraph/blob/8b0a866ad9a0a4807c4836c577ce65ecac5fd283/pyqtgraph/graphicsItems/ErrorBarItem.py. 

Potentially no numpy array-specific methods were being called until some other change in PyQtGraph, hence this problem occurring now.

Flake8 and YAPF checked. I would have added an automated test but there weren't any for this plotting code. I verified the fix by being able to plot data with error bars that previously caused the described AttributeError to be raised
![image](https://user-images.githubusercontent.com/5368222/125981054-229fc88e-4753-47f5-8e4c-3f7446577254.png)
Do let me know if there's any more testing I can do.

Closes #247 