### PR TITLE
Allow non-implemented build_fragment for super() with multiple inheritance

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -259,8 +259,7 @@ class Fragment(HasEnvironment):
         :param kwargs: Any extra keyword arguments that were passed to the
             ``HasEnvironment`` constructor.
         """
-        raise NotImplementedError("build_fragment() not implemented; "
-                                  "override it to add parameters/result channels.")
+        pass
 
     def setattr_fragment(self, name: str, fragment_class: Type["Fragment"], *args,
                          **kwargs) -> "Fragment":


### PR DESCRIPTION
This would allow using `super()` with multiple inheritance in `build_fragment()`. Currently, the `Fragment`'s own `build_fragment()` method raises in the following minimal example.
```python
class F(Fragment):
    def build_fragment(self):
        super().build_fragment()

class G(Fragment):
    def build_fragment(self):
        super().build_fragment()

class C(F, G):
    def build_fragment(self):
        super().build_fragment()
```