### PR TITLE
results: Handle missing schema in dump_scan()

### DIFF
--- a/ndscan/results/arguments.py
+++ b/ndscan/results/arguments.py
@@ -64,6 +64,10 @@ def dump_scan(schema: Dict[str, Any]) -> Iterable[str]:
     :return: Generator yielding the output line-by-line.
     """
 
+    if "scan" not in schema:
+        yield "No scan information present"
+        return
+
     scan = schema["scan"]
 
     axes = scan["axes"]


### PR DESCRIPTION
This fixes ndscan.show for files which don't have ndscan
argument information, but might have one or more ndscan roots
(e.g. servos with TopLevelRunner).
