### PR TITLE
scan_runner: Make sure to always close core device connection

### DIFF
--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -177,7 +177,7 @@ class ScanRunner(HasEnvironment):
                     return
             finally:
                 self._kscan_fragment.host_cleanup()
-            self.core.comm.close()
+                self.core.comm.close()
             self.scheduler.pause()
             self._kscan_fragment.recompute_param_defaults()
 


### PR DESCRIPTION
IIRC this was a prophylactic change made while reading the source
a while back; not sure if this is actually caused any trouble.
