### PR TITLE
Allow `dataset("…")` without fallback as default value

### DIFF
--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -620,7 +620,7 @@ class OverrideEntry(LayoutWidget):
                 return
         try:
 
-            def get_dataset(key, default):
+            def get_dataset(key, default=None):
                 try:
                     bs = manager_datasets.backing_store
                 except AttributeError:
@@ -631,6 +631,9 @@ class OverrideEntry(LayoutWidget):
                 try:
                     return bs[key][1]
                 except KeyError:
+                    if default is None:
+                        raise KeyError(f"Could not read dataset '{key}', but no " +
+                                       "fallback default value given") from None
                     return default
                 return bs
 

--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -635,7 +635,6 @@ class OverrideEntry(LayoutWidget):
                         raise KeyError(f"Could not read dataset '{key}', but no " +
                                        "fallback default value given") from None
                     return default
-                return bs
 
             value = eval_param_default(self.schema["default"], get_dataset)
         except Exception as e:

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -568,23 +568,18 @@ class Fragment(HasEnvironment):
                 continue
             s._collect_result_channels(channels)
 
-    def _get_dataset_or_set_default(self, key, default) -> Any:
+    def _get_dataset_or_set_default(self, key, default=None) -> Any:
         try:
-            try:
-                return self.get_dataset(key)
-            except KeyError:
+            return self.get_dataset(key)
+        except KeyError:
+            if default is None:
+                raise KeyError(f"Dataset '{key}' does not exist, but no " +
+                               "fallback default value specified") from None
+            else:
                 logger.warning("Setting dataset '%s' to default value (%s)", key,
                                default)
                 self.set_dataset(key, default, broadcast=True, persist=True)
                 return default
-        except Exception as e:
-            # FIXME: This currently occurs when build()ing experiments with dataset
-            # defaults from within an examine worker, i.e. when scanning the repository
-            # or recomputing arguments, because datasets can't be accessed there. We
-            # should probably silently ignore missing datasets there, and set them
-            # accordingly when the experiment is actually run.
-            logger.warning("Unexpected error evaluating dataset default: %s", e)
-            return default
 
 
 class ExpFragment(Fragment):

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -10,8 +10,8 @@
 
 from artiq.language import *
 from artiq.language import units
-from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
-from ..utils import eval_param_default
+from typing import Any, Dict, Optional, Tuple, Type, Union
+from ..utils import eval_param_default, GetDataset
 
 __all__ = ["FloatParam", "IntParam", "StringParam"]
 
@@ -268,7 +268,7 @@ class FloatParam:
             "spec": spec,
         }
 
-    def eval_default(self, get_dataset: Callable) -> float:
+    def eval_default(self, get_dataset: GetDataset) -> float:
         if type(self.default) is str:
             return eval_param_default(self.default, get_dataset)
         return self.default
@@ -328,7 +328,7 @@ class IntParam:
             "spec": spec
         }
 
-    def eval_default(self, get_dataset: Callable) -> int:
+    def eval_default(self, get_dataset: GetDataset) -> int:
         if type(self.default) is str:
             return eval_param_default(self.default, get_dataset)
         return self.default
@@ -369,7 +369,7 @@ class StringParam:
             }
         }
 
-    def eval_default(self, get_dataset: Callable) -> str:
+    def eval_default(self, get_dataset: GetDataset) -> str:
         return eval_param_default(self.default, get_dataset)
 
     def make_store(self, identity: Tuple[str, str], value: str) -> StringParamStore:

--- a/ndscan/plots/utils.py
+++ b/ndscan/plots/utils.py
@@ -168,7 +168,7 @@ def extract_linked_datasets(param_schema: Dict[str, Any]) -> List[str]:
     datasets = []
     try:
         # Intercept dataset() to build up list of accessed keys.
-        def log_datasets(dataset, default):
+        def log_datasets(dataset, default=None):
             datasets.append(dataset)
             return default
 

--- a/ndscan/utils.py
+++ b/ndscan/utils.py
@@ -2,9 +2,9 @@
 
 from enum import Enum, unique
 import oitg.fitting
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable, Optional, Protocol, TypeVar
 
-#: Registry of well-known fit procecure names.
+#: Registry of well-known fit procedure names.
 FIT_OBJECTS = {
     n: getattr(oitg.fitting, n)
     for n in [
@@ -89,7 +89,21 @@ def shorten_to_unambiguous_suffixes(
     return shortened_fqns
 
 
-def eval_param_default(value: str, get_dataset: Callable) -> Any:
+T = TypeVar("T")
+
+
+class GetDataset(Protocol):
+    """Callback which is used to implement the user-facing ``dataset(…)`` default value
+    syntax.
+
+    If the ``key`` dataset does not exist, the callback should return the value given in
+    the second parameter, ``default``, or if that is not specified, raise an exception.
+    """
+    def __call__(self, key: str, default: Optional[T] = None, /) -> T:
+        ...
+
+
+def eval_param_default(value: str, get_dataset: GetDataset) -> Any:
     from artiq.language import units
     env = {name: getattr(units, name) for name in units.__all__}
     env.update({"dataset": get_dataset})

--- a/ndscan/utils.py
+++ b/ndscan/utils.py
@@ -99,7 +99,7 @@ class GetDataset(Protocol):
     If the ``key`` dataset does not exist, the callback should return the value given in
     the second parameter, ``default``, or if that is not specified, raise an exception.
     """
-    def __call__(self, key: str, default: Optional[T] = None, /) -> T:
+    def __call__(self, key: str, default: Optional[T] = None) -> T:
         ...
 
 

--- a/test/test_experiment_fragment.py
+++ b/test/test_experiment_fragment.py
@@ -14,12 +14,22 @@ class DatasetDefaultFragment(Fragment):
         self.setattr_param("bar", IntParam, "Bar", default="dataset('bar', 2)")
 
 
+class DatasetNoFallbackDefaultFragment(Fragment):
+    def build_fragment(self):
+        self.setattr_param("baz", IntParam, "Baz", default="dataset('baz')")
+
+
 class TestParamDefaults(HasEnvironmentCase):
     def test_nonexistent_datasets(self):
         ddf = self.create(DatasetDefaultFragment, [])
         ddf.init_params()
         self.assertEqual(ddf.foo.get(), 1)
         self.assertEqual(ddf.bar.get(), 2)
+
+    def test_nonexistent_datasets_no_default(self):
+        dnfdf = self.create(DatasetNoFallbackDefaultFragment, [])
+        with self.assertRaises(ValueError):
+            dnfdf.init_params()
 
     def test_datasets(self):
         ddf = self.create(DatasetDefaultFragment, [])


### PR DESCRIPTION
This will cause experiments to fail to be built for
datasets that don't exist, and the dashboard argument
editors to potentially fail to open if the master dataset
sync has not yet completed. For those reasons, a default
value was originally required, but several users prefer
the "louder" failure behaviour over the warning + fallback.

GitHub: Fixes #209.