### PR TITLE
experiment: Don't execute {device,host}_{setup,cleanup}() for subscanned fragments

### DIFF
--- a/ndscan/experiment/subscan.py
+++ b/ndscan/experiment/subscan.py
@@ -207,9 +207,9 @@ def setattr_subscan(owner: Fragment,
 
     assert owner._building, "Can only call install_subscan() during build_fragment()"
     assert not hasattr(owner, scan_name), "Field '{}' already exists".format(scan_name)
-    assert fragment in owner._subfragments, "Can only scan immediate subfragments"
-    assert fragment not in owner._absorbed_results_subfragments, \
-        "Subfragment result channels already used (is there already another scan?)"
+
+    # Our own ScanRunner takes care of the fragment lifecycle.
+    owner.detach_fragment(fragment)
 
     # Override target parameter stores with newly created stores.
     # TODO: Potentially make handles have identity and accept them directly.
@@ -236,7 +236,7 @@ def setattr_subscan(owner: Fragment,
     # we redirect the results to ArraySinks…
     original_channels = {}
     fragment._collect_result_channels(original_channels)
-    owner._absorbed_results_subfragments.add(fragment)
+    owner._detached_subfragments.add(fragment)
 
     child_result_sinks = {}
     for channel in original_channels.values():

--- a/test/test_experiment_subscan.py
+++ b/test/test_experiment_subscan.py
@@ -176,6 +176,17 @@ class SubscanCase(ExpFragmentCase):
         # values.
         self.assertEqual(annotations, [x_location, y_location])
 
+    def test_fragment_detach(self):
+        parent = self.create(Scan1DFragment, AddOneFragment)
+        run_fragment_once(parent)
+
+        # Make sure the setup and cleanup methods aren't also called during the parent
+        # fragment setup/cleanup (in addition to the subscan).
+        self.assertEqual(parent.child.num_host_setup_calls, 1)
+        self.assertEqual(parent.child.num_device_setup_calls, 4)
+        self.assertEqual(parent.child.num_device_cleanup_calls, 1)
+        self.assertEqual(parent.child.num_host_cleanup_calls, 1)
+
 
 class RunSubscanTwiceFragment(ExpFragment):
     def build_fragment(self):


### PR DESCRIPTION
Previously, an empty version of the methods would need to be provided
manually in the parent fragment to avoid the scanned fragment to be
automatically set up/torn down as part of the default recursive
implementation. This is especially annoying as it might cause a lot
of extraneous kernel compilations.

GitHub: Fixes #288.
