### PR TITLE
Add centre/span and infinitely expanding scans; sync scan settings between types

### DIFF
--- a/ndscan/experiment/scan_generator.py
+++ b/ndscan/experiment/scan_generator.py
@@ -29,6 +29,8 @@ class ScanGenerator:
 
 
 class RefiningGenerator(ScanGenerator):
+    """Generates progressively finer grid by halving distance between points each level.
+    """
     def __init__(self, lower, upper, randomise_order):
         self.lower = float(min(lower, upper))
         self.upper = float(max(lower, upper))
@@ -36,6 +38,8 @@ class RefiningGenerator(ScanGenerator):
 
     def has_level(self, level: int) -> bool:
         ""
+        # For floating-point parameters, a refining scan, in practical terms, never runs
+        # out of points. Will need to be amended for integer parameters.
         return True
 
     def points_for_level(self, level: int, rng=None) -> List[Any]:
@@ -59,6 +63,7 @@ class RefiningGenerator(ScanGenerator):
 
 
 class LinearGenerator(ScanGenerator):
+    """Generates equally spaced points between two endpoints."""
     def __init__(self, start, stop, num_points, randomise_order):
         if num_points < 2:
             raise ValueError("Need at least 2 points in linear scan")
@@ -90,6 +95,7 @@ class LinearGenerator(ScanGenerator):
 
 
 class ListGenerator(ScanGenerator):
+    """Generates points by reading from an explicitly specified list."""
     def __init__(self, values, randomise_order):
         self.values = values
         self.randomise_order = randomise_order

--- a/test/test_experiment_scan_generator.py
+++ b/test/test_experiment_scan_generator.py
@@ -1,5 +1,6 @@
+import numpy as np
 import unittest
-from ndscan.experiment.scan_generator import ExpandingGenerator
+from ndscan.experiment.scan_generator import CentreSpanGenerator, ExpandingGenerator
 
 
 class ScanGeneratorCase(unittest.TestCase):
@@ -62,3 +63,57 @@ class ScanGeneratorCase(unittest.TestCase):
         self.assertEqual(gen.points_for_level(1), [-1.0, 1.0])
         self.assertTrue(gen.has_level(10))
         self.assertEqual(gen.points_for_level(10), [-10.0, 10.0])
+
+    def test_centre_empty(self):
+        with self.assertRaises(ValueError):
+            CentreSpanGenerator(centre=0.0,
+                                half_span=1.0,
+                                num_points=0,
+                                randomise_order=False)
+
+    def test_centre_one(self):
+        gen = CentreSpanGenerator(centre=0.0,
+                                  half_span=1.0,
+                                  num_points=1,
+                                  randomise_order=True)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0, np.random), [0.0])
+        self.assertFalse(gen.has_level(1))
+
+    def test_centre_two(self):
+        gen = CentreSpanGenerator(centre=0.0,
+                                  half_span=1.0,
+                                  num_points=2,
+                                  randomise_order=False)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0), [-1.0, 1.0])
+        self.assertFalse(gen.has_level(1))
+
+    def test_centre_three(self):
+        gen = CentreSpanGenerator(centre=0.0,
+                                  half_span=1.0,
+                                  num_points=3,
+                                  randomise_order=False)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0), [-1.0, 0.0, 1.0])
+        self.assertFalse(gen.has_level(1))
+
+    def test_centre_lower_lim(self):
+        gen = CentreSpanGenerator(centre=0.0,
+                                  half_span=1.0,
+                                  num_points=2,
+                                  randomise_order=False,
+                                  limit_lower=0.0)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0), [0.0, 1.0])
+        self.assertFalse(gen.has_level(1))
+
+    def test_centre_upper_lim(self):
+        gen = CentreSpanGenerator(centre=0.0,
+                                  half_span=1.0,
+                                  num_points=2,
+                                  randomise_order=False,
+                                  limit_upper=0.0)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0), [-1.0, 0.0])
+        self.assertFalse(gen.has_level(1))

--- a/test/test_experiment_scan_generator.py
+++ b/test/test_experiment_scan_generator.py
@@ -1,0 +1,64 @@
+import unittest
+from ndscan.experiment.scan_generator import ExpandingGenerator
+
+
+class ScanGeneratorCase(unittest.TestCase):
+    def test_expanding_trivial(self):
+        gen = ExpandingGenerator(centre=0.0,
+                                 spacing=10.0,
+                                 randomise_order=False,
+                                 limit_lower=-1.0,
+                                 limit_upper=1.0)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0), [0.0])
+        for i in range(1, 3):
+            self.assertFalse(gen.has_level(i))
+
+    def test_expanding_one(self):
+        gen = ExpandingGenerator(centre=0.0,
+                                 spacing=1.0,
+                                 randomise_order=False,
+                                 limit_lower=-1.0,
+                                 limit_upper=1.0)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0), [0.0])
+        self.assertTrue(gen.has_level(1))
+        self.assertEqual(gen.points_for_level(1), [-1.0, 1.0])
+        self.assertFalse(gen.has_level(2))
+
+    def test_expanding_lower_lim(self):
+        gen = ExpandingGenerator(centre=0.0,
+                                 spacing=1.0,
+                                 randomise_order=False,
+                                 limit_lower=-1.0)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0), [0.0])
+        self.assertTrue(gen.has_level(1))
+        self.assertEqual(gen.points_for_level(1), [-1.0, 1.0])
+        self.assertTrue(gen.has_level(2))
+        self.assertEqual(gen.points_for_level(2), [2.0])
+        self.assertTrue(gen.has_level(10))
+        self.assertEqual(gen.points_for_level(10), [10.0])
+
+    def test_expanding_upper_lim(self):
+        gen = ExpandingGenerator(centre=0.0,
+                                 spacing=1.0,
+                                 randomise_order=False,
+                                 limit_upper=1.0)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0), [0.0])
+        self.assertTrue(gen.has_level(1))
+        self.assertEqual(gen.points_for_level(1), [-1.0, 1.0])
+        self.assertTrue(gen.has_level(2))
+        self.assertEqual(gen.points_for_level(2), [-2.0])
+        self.assertTrue(gen.has_level(10))
+        self.assertEqual(gen.points_for_level(10), [-10.0])
+
+    def test_expanding_no_lim(self):
+        gen = ExpandingGenerator(centre=0.0, spacing=1.0, randomise_order=False)
+        self.assertTrue(gen.has_level(0))
+        self.assertEqual(gen.points_for_level(0), [0.0])
+        self.assertTrue(gen.has_level(1))
+        self.assertEqual(gen.points_for_level(1), [-1.0, 1.0])
+        self.assertTrue(gen.has_level(10))
+        self.assertEqual(gen.points_for_level(10), [-10.0, 10.0])


### PR DESCRIPTION
- experiment: Scan generator docstrings [nfc]
- experiment: Add infinitely expanding scan generator
- experiment: Add linear scan parametrised by center and (half-)span
- dashboard: Refactor scan option selection code [nfc]
- dashboard: Synchronise equivalent options between scan types
- dashboard: Add expanding and centre/span scans
