### PR TITLE
Split up setattr_param_rebind, add AggregateExpFragment

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -485,8 +485,8 @@ class Fragment(HasEnvironment):
 
         This method should be called before any of the fragment's user-defined functions
         are used (but after the constructor -> :meth:`build` -> :meth`build_fragment()`
-        has completed). Most likely, the top-level fragment will be called from a
-        :mod:`ndscan.experiment.entry_point` which already take care of this. In cases
+        has completed). Most likely, the top-level fragment will be called from an
+        :mod:`ndscan.experiment.entry_point`, which already take care of this. In cases
         where fragments are used in a different context, for example from a standalone
         ``EnvExperiment``, this method must be called manually.
 
@@ -619,7 +619,7 @@ class ExpFragment(Fragment):
 
         Unless running in the `prepare` pipeline state is absolutely necessary for
         runtime performance, lazily running the requisite initialisation code in
-        :meth:`host_setup` is usually preferrable, as this naturally composes across the
+        :meth:`host_setup` is usually preferable, as this naturally composes across the
         ndscan fragment tree.
         """
         pass

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -521,7 +521,9 @@ class Fragment(HasEnvironment):
 
         For parameters where the default value was previously used, the expression is
         evaluated again – thus for instance fetching new dataset values –, and assigned
-        to the existing parameter store.
+        to the existing parameter store. An informative message is logged if the value
+        changed, such that changes remain traceable after the fact (e.g. when an
+        experiment is resumed after a calibration interruption).
         """
         for param, store in self._default_params:
             value = param.eval_default(self._get_dataset_or_set_default)

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -644,12 +644,28 @@ class ExpFragment(Fragment):
 
 
 class TransitoryError(Exception):
-    """Transitory error encountered while executing a fragment, which is expected to
+    r"""Transitory error encountered while executing a fragment, which is expected to
     clear itself up if it is attempted again without any further changes.
+
+    Such errors are never raised by the ndscan infrastructure itself, but can be thrown
+    from user fragment implementations in response to e.g. some temporary hardware
+    conditions such as a momentarily insufficient level of laser power.
+
+    :mod:`ndscan.experiment.entry_point`\ s will attempt to handle transitory errors,
+    e.g. by retrying execution some amount of times. If fragments are manually executed
+    from user code, it will often be appropriate to do this as well, unless the user
+    code base does not use transitory errors at all.
     """
     pass
 
 
 class RestartKernelTransitoryError(TransitoryError):
-    """Transitory error where the kernel should be restarted before retrying."""
+    """:class:`.TransitoryError` where, as part of recovering from it, the kernel should
+    be restarted before retrying.
+
+    This can be used for cases where remedying the error requires
+    :meth:`.Fragment.host_setup()` to be run again, such as for cases where the
+    experiments needs to yield back to the scheduler (e.g. for an ion loss event to be
+    remedied by a second reloading experiment).
+    """
     pass

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -64,6 +64,19 @@ class ReboundReboundAddOneFragment(ExpFragment):
         self.rebound_add_one.run_once()
 
 
+class MultiReboundAddOneFragment(ExpFragment):
+    def build_fragment(self):
+        self.setattr_fragment("first", AddOneFragment)
+        self.setattr_fragment("second", AddOneFragment)
+        self.setattr_param_like("value", self.first)
+        self.bind_param("value", self.first)
+        self.bind_param("value", self.second)
+
+    def run_once(self):
+        self.first.run_once()
+        self.second.run_once()
+
+
 class AddOneCustomAnalysisFragment(AddOneFragment):
     def get_default_analyses(self):
         return [CustomAnalysis({self.value}, self._analyze)]

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -11,10 +11,14 @@ class AddOneFragment(ExpFragment):
         self.setattr_param("value", FloatParam, "Value to return", 0.0)
         self.setattr_result("result", FloatChannel)
 
+        self.num_prepare_calls = 0
         self.num_host_setup_calls = 0
         self.num_device_setup_calls = 0
         self.num_host_cleanup_calls = 0
         self.num_device_cleanup_calls = 0
+
+    def prepare(self):
+        self.num_prepare_calls += 1
 
     def host_setup(self):
         self.num_host_setup_calls += 1
@@ -69,8 +73,8 @@ class MultiReboundAddOneFragment(ExpFragment):
         self.setattr_fragment("first", AddOneFragment)
         self.setattr_fragment("second", AddOneFragment)
         self.setattr_param_like("value", self.first)
-        self.bind_param("value", self.first)
-        self.bind_param("value", self.second)
+        self.first.bind_param("value", self.value)
+        self.second.bind_param("value", self.value)
 
     def run_once(self):
         self.first.run_once()
@@ -177,11 +181,41 @@ class TwoAnalysisFragment(ExpFragment):
         self.setattr_param("b", FloatParam, "b", 0.0)
 
     def get_default_analyses(self):
-        def analyse(coords, values, results):
-            next(iter(results.values())).push(42.0)
-            return []
+        def make_analyse(channel_name):
+            def analyse(coords, values, results):
+                # Explicitly specify the channel name instead of just taking the only
+                # value to make sure the names work as expected from the user side.
+                results[channel_name].push(42.0)
+                return []
+
+            return analyse
 
         return [
-            CustomAnalysis([self.a], analyse, [FloatChannel("result_a")]),
-            CustomAnalysis([self.b], analyse, [FloatChannel("result_b")])
+            CustomAnalysis([self.a], make_analyse("result_a"),
+                           [FloatChannel("result_a")]),
+            CustomAnalysis([self.b], make_analyse("result_b"),
+                           [FloatChannel("result_b")])
         ]
+
+
+class AddOneAggregate(AggregateExpFragment):
+    def build_fragment(self) -> None:
+        self.setattr_fragment("a", AddOneFragment)
+        self.setattr_fragment("b", AddOneFragment)
+        return super().build_fragment([self.a, self.b])
+
+
+class TrivialKernelAggregate(AggregateExpFragment):
+    def build_fragment(self) -> None:
+        self.setattr_fragment("a", TrivialKernelFragment)
+        self.setattr_fragment("b", TrivialKernelFragment)
+        return super().build_fragment([self.a, self.b])
+
+
+class TwoAnalysisAggregate(AggregateExpFragment):
+    def build_fragment(self) -> None:
+        self.setattr_fragment("first", TwoAnalysisFragment)
+        self.setattr_fragment("second", TwoAnalysisFragment)
+        self.setattr_param_rebind("a", self.first)
+        self.second.bind_param("a", self.a)
+        return super().build_fragment([self.first, self.second])

--- a/test/test_experiment_fragment.py
+++ b/test/test_experiment_fragment.py
@@ -4,7 +4,8 @@ Tests for general fragment tree behaviour.
 
 from ndscan.experiment import *
 from ndscan.experiment.parameters import IntParamStore
-from fixtures import AddOneFragment, ReboundReboundAddOneFragment
+from fixtures import (AddOneFragment, MultiReboundAddOneFragment,
+                      ReboundReboundAddOneFragment)
 from mock_environment import HasEnvironmentCase
 
 
@@ -60,6 +61,13 @@ class TestRebinding(HasEnvironmentCase):
         rrf.override_param("value", 2)
         result = run_fragment_once(rrf)[rrf.rebound_add_one.add_one.result]
         self.assertEqual(result, 3)
+
+    def test_multi_rebind(self):
+        mrf = self.create(MultiReboundAddOneFragment, [])
+        mrf.override_param("value", 2)
+        result = run_fragment_once(mrf)
+        self.assertEqual(result[mrf.first.result], 3)
+        self.assertEqual(result[mrf.second.result], 3)
 
 
 class TestMisc(HasEnvironmentCase):


### PR DESCRIPTION
- fragment: Fix typos [nfc]
- fragment: Explain recompute_param_defaults() logging [nfc]
- experiment: Improve transitory error docstrings [nfc]
- experiment: Split up setattr_param_rebind()
- experiment: Add AggregateExpFragment
