### PR TITLE
dataset_janitor: Make sure to explicitly close all connections on failure

### DIFF
--- a/ndscan/dataset_janitor.py
+++ b/ndscan/dataset_janitor.py
@@ -236,7 +236,7 @@ async def run(args):
         # Execute pending deletion requests.
         while all_connected():
             while deletions and all_connected():
-                rid, timestamp = deletions.popitem()
+                rid, timestamp = next(iter(deletions.items()))
                 if (delay := timestamp - time.monotonic()) > 0:
                     await asyncio.sleep(delay)
                 logger.info(f"ndscan RID {rid} timed out, cleaning up datasets.")
@@ -252,6 +252,8 @@ async def run(args):
                         dataset_db.close_rpc()
                         dataset_db = None
                         break
+                # All deletions in first item processed, go to next one.
+                deletions.popitem()
             if all_connected():
                 wake_loop.clear()
                 await wake_loop.wait()

--- a/ndscan/dataset_janitor.py
+++ b/ndscan/dataset_janitor.py
@@ -246,6 +246,12 @@ async def run(args):
                 for key in to_remove:
                     try:
                         await dataset_db.delete(key)
+                    except KeyError:
+                        # This shouldn't happen, but there could be some race condition
+                        # between the subscriber tracking the datasets and this routine
+                        # if they are manually deleted.
+                        logger.exception(f"Failed to delete dataset '{key}', as it " +
+                                         "does not exist anymore.")
                     except Exception:
                         logger.exception(
                             f"Failed to delete dataset '{key}', reconnecting.")


### PR DESCRIPTION
Not sure whether this was actually an issue, but we have been
sporadically seeing "Too many open files" on the master process
in one of several experimental setups.
