### PR TITLE
Potential bugfix - _default_params currently grows infinitely

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -573,6 +573,11 @@ class Fragment(HasEnvironment):
                 if path_matches_spec(self._fragment_path, override_pathspec):
                     store = override_store
             if not store:
+                for default_param, default_store in self._default_params:
+                    if param == default_param:
+                        store = default_store
+                        break
+            if not store:
                 identity = (param.fqn, self._stringize_path())
                 try:
                     value = param.eval_default(self._get_dataset_or_set_default)

--- a/test/test_experiment_entrypoint.py
+++ b/test/test_experiment_entrypoint.py
@@ -10,7 +10,8 @@ from sipyco import pyon
 from fixtures import (AddOneFragment, ReboundAddOneFragment, TrivialKernelFragment,
                       TransitoryErrorFragment, MultiPointTransitoryErrorFragment,
                       RequestTerminationFragment, AddOneAggregate,
-                      TrivialKernelAggregate, TwoAnalysisAggregate, ReadParamDefault)
+                      TrivialKernelAggregate, TwoAnalysisAggregate, ReadParamDefault,
+                      MultiReboundAddOneFragment)
 from mock_environment import HasEnvironmentCase
 
 ScanAddOneExp = make_fragment_scan_exp(AddOneFragment)
@@ -322,6 +323,30 @@ class RunOnceCase(HasEnvironmentCase):
     def test_run_once_host(self):
         fragment = self.create(AddOneFragment, [])
         self.assertEqual(run_fragment_once(fragment), {fragment.result: 1.0})
+
+    def test_run_once_repeated(self):
+        fragment = self.create(AddOneFragment, [])
+
+        self.assertEqual(run_fragment_once(fragment), {fragment.result: 1.0})
+        self.assertEqual(len(fragment._default_params), 1)
+
+        self.assertEqual(run_fragment_once(fragment), {fragment.result: 1.0})
+        self.assertEqual(len(fragment._default_params), 1)
+
+    def test_run_once_repeated_rebound(self):
+        fragment = self.create(MultiReboundAddOneFragment, [])
+
+        self.assertEqual(run_fragment_once(fragment), {
+            fragment.first.result: 1.0,
+            fragment.second.result: 1.0
+        })
+        self.assertEqual(len(fragment._default_params), 1)
+
+        self.assertEqual(run_fragment_once(fragment), {
+            fragment.first.result: 1.0,
+            fragment.second.result: 1.0
+        })
+        self.assertEqual(len(fragment._default_params), 1)
 
     def test_run_once_kernel(self):
         fragment = self.create(TrivialKernelFragment, [])


### PR DESCRIPTION
Hi @dnadlinger,

I've opened this PR not because it should be merged, but because I wanted to highlight what I think may be a bug, and ask you if it is. 

At the moment, it seems like calling `run_once()` more than once results in repeated calls to `init_params()` which then results in `Fragment._default_params` having another entry appended to it. I've added a unit test in this PR to show the problem. 

Do you consider this a bug? If not, what's the recommended way of calling an ExpFragment's `run_once` functionality from an `EnvExperiment` more than once in a session?

PS thanks for the library, it's great :)