### PR TITLE
Create new Param instance on rebind to set scale

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -363,10 +363,10 @@ class Fragment(HasEnvironment):
             "already rebound?".format(original_name))
 
         template_param = original_owner._free_params[original_name]
-        new_param = deepcopy(template_param)
-        new_param.fqn = self.fqn + "." + name
-        for k, v in kwargs.items():
-            setattr(new_param, k, v)
+        init_params = deepcopy(template_param.init_params)
+        init_params.update(kwargs)
+        init_params["fqn"] = self.fqn + "." + name
+        new_param = template_param.__class__(**init_params)
         self._free_params[name] = new_param
         new_handle = new_param.HandleType(self, name)
         setattr(self, name, new_handle)

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -261,7 +261,15 @@ def resolve_numeric_scale(scale: Optional[float], unit: str) -> float:
                        "the scale manually".format(unit))
 
 
-class FloatParam:
+class ParamBase:
+    def __init__(self, **kwargs):
+        # Store kwargs for param rebinding
+        self.init_params = kwargs
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class FloatParam(ParamBase):
     HandleType = FloatParamHandle
     StoreType = FloatParamStore
     CompilerType = TFloat
@@ -278,17 +286,18 @@ class FloatParam:
                  step: Optional[float] = None,
                  is_scannable: bool = True):
 
-        self.fqn = fqn
-        self.description = description
-        self.default = default
-        self.min = min
-        self.max = max
-
-        self.unit = unit
+        ParamBase.__init__(self,
+                           fqn=fqn,
+                           description=description,
+                           default=default,
+                           min=min,
+                           max=max,
+                           unit=unit,
+                           scale=scale,
+                           step=step,
+                           is_scannable=is_scannable)
         self.scale = resolve_numeric_scale(scale, unit)
-
         self.step = step if step is not None else self.scale / 10.0
-        self.is_scannable = is_scannable
 
     def describe(self) -> Dict[str, Any]:
         spec = {
@@ -326,7 +335,7 @@ class FloatParam:
         return FloatParamStore(identity, value)
 
 
-class IntParam:
+class IntParam(ParamBase):
     HandleType = IntParamHandle
     StoreType = IntParamStore
     CompilerType = TInt32
@@ -341,13 +350,16 @@ class IntParam:
                  unit: str = "",
                  scale: Optional[int] = None,
                  is_scannable: bool = True):
-        self.fqn = fqn
-        self.description = description
-        self.default = default
-        self.min = min
-        self.max = max
 
-        self.unit = unit
+        ParamBase.__init__(self,
+                           fqn=fqn,
+                           description=description,
+                           default=default,
+                           min=min,
+                           max=max,
+                           unit=unit,
+                           scale=scale,
+                           is_scannable=is_scannable)
         self.scale = resolve_numeric_scale(scale, unit)
         if self.scale != 1:
             raise NotImplementedError(
@@ -386,7 +398,7 @@ class IntParam:
         return IntParamStore(identity, value)
 
 
-class StringParam:
+class StringParam(ParamBase):
     HandleType = StringParamHandle
     StoreType = StringParamStore
     CompilerType = TStr
@@ -396,10 +408,12 @@ class StringParam:
                  description: str,
                  default: str,
                  is_scannable: bool = True):
-        self.fqn = fqn
-        self.description = description
-        self.default = default
-        self.is_scannable = is_scannable
+
+        ParamBase.__init__(self,
+                           fqn=fqn,
+                           description=description,
+                           default=default,
+                           is_scannable=is_scannable)
 
     def describe(self) -> Dict[str, Any]:
         return {

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -53,7 +53,7 @@ class AddOneFragment(ExpFragment):
 class ReboundAddOneFragment(ExpFragment):
     def build_fragment(self):
         self.setattr_fragment("add_one", AddOneFragment)
-        self.setattr_param_rebind("value", self.add_one)
+        self.setattr_param_rebind("value", self.add_one, unit="ms")
 
     def run_once(self):
         self.add_one.run_once()


### PR DESCRIPTION
Addresses #210 

<del/>FloatParam and IntParam recompute scale if required. 

<del/>Misses (very) edge case:
        - Param has fixed desired scale.
	- Param is rebound with new unit (but you want the old scale?)
	- Param will be adjusted to match scale of new unit
<del/>More importantly - catches not setting the scale manually and wanting to change unit

<del/>StringParam passes

Create `ParamBase` class for storing initialisation parameters
Now create new `Param` on rebind and call with stored + updated initialisation parameters.
This allows the scale for int/float params to be recomputed if required