### PR TITLE
fragment: Cannot set datasets to default in examine

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -661,11 +661,14 @@ class Fragment(HasEnvironment):
             if default is None:
                 raise KeyError(f"Dataset '{key}' does not exist, but no " +
                                "fallback default value specified") from None
-            else:
-                logger.warning("Setting dataset '%s' to default value (%s)", key,
-                               default)
+            try:
                 self.set_dataset(key, default, broadcast=True, persist=True)
-                return default
+                logger.warning("Set dataset '%s' to default value (%s)", key, default)
+            except AttributeError:
+                logger.debug(
+                    "Failed to set dataset '%s' to default value (%s); " +
+                    "probably running in examine phase", key, default)
+            return default
 
 
 class ExpFragment(Fragment):

--- a/test/mock_environment.py
+++ b/test/mock_environment.py
@@ -29,6 +29,14 @@ class MockDatasetDB:
         del self.data[key]
 
 
+class MockExamineDatasetMgr:
+    def __init__(self, db):
+        self.db = db
+
+    def get(self, key, archive=False):
+        return self.db.get(key)
+
+
 class MockScheduler:
     def __init__(self):
         self.rid = 0
@@ -65,7 +73,6 @@ class MockDeviceDB:
 class HasEnvironmentCase(unittest.TestCase):
     def setUp(self):
         self.dataset_db = MockDatasetDB()
-        self.dataset_mgr = DatasetManager(self.dataset_db)
         self.device_db = MockDeviceDB()
         self.ccb = unittest.mock.Mock()
         self.core = unittest.mock.Mock()
@@ -77,10 +84,11 @@ class HasEnvironmentCase(unittest.TestCase):
                                             "scheduler": self.scheduler
                                         })
 
-    def create(self, klass, *args, env_args=None, **kwargs):
-        return klass(
-            (self.device_mgr, self.dataset_mgr, ProcessArgumentManager(
-                env_args or {}), None), *args, **kwargs)
+    def create(self, klass, *args, env_args=None, like_examine=False, **kwargs):
+        dataset_mgr_cls = MockExamineDatasetMgr if like_examine else DatasetManager
+        arg_mgr = ProcessArgumentManager(env_args or {})
+        return klass((self.device_mgr, dataset_mgr_cls(self.dataset_db), arg_mgr, None),
+                     *args, **kwargs)
 
 
 class ExpFragmentCase(HasEnvironmentCase):

--- a/test/test_experiment_fragment.py
+++ b/test/test_experiment_fragment.py
@@ -27,6 +27,13 @@ class TestParamDefaults(HasEnvironmentCase):
         self.assertEqual(ddf.foo.get(), 1)
         self.assertEqual(ddf.bar.get(), 2)
 
+    def test_nonexistent_datasets_in_examine(self):
+        # Should not fail due to not being able to set the default.
+        ddf = self.create(DatasetDefaultFragment, [], like_examine=True)
+        ddf.init_params()
+        self.assertEqual(ddf.foo.get(), 1)
+        self.assertEqual(ddf.bar.get(), 2)
+
     def test_nonexistent_datasets_no_default(self):
         dnfdf = self.create(DatasetNoFallbackDefaultFragment, [])
         with self.assertRaises(ValueError):


### PR DESCRIPTION
In the "examine" phase (when scanning the repository/…),
`set_dataset` is expected to fail.

Needs a unit test still.