### PR TITLE
argument_editor: examine_arginfo -> compute_expdesc

### DIFF
--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -481,7 +481,7 @@ class ArgumentEditor(QtWidgets.QTreeWidget):
 
     async def _recompute_vanilla_argument(self, name):
         try:
-            arginfo, _ = await self.manager.examine_arginfo(self.expurl)
+            arginfo, _ = await self.manager.compute_expdesc(self.expurl)
         except Exception:
             logger.error("Could not recompute argument '%s' of '%s'",
                          name,


### PR DESCRIPTION
Fixes the "refresh" buttons for regular ARTIQ arguments.

The name change (previously made in our local fork of ARTIQ) was
not carried through into upstream (reverted in local commit
ion-trap/artiq@790448c844eee6ee50a04019f284ef57060eaf5a).

No regression tests as this only concerns the argument editor,
for which we don't have automated tests.
