### PR TITLE
Create BoolParam parameter type

### DIFF
--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -584,6 +584,8 @@ class ArgumentEditor(QtWidgets.QTreeWidget):
         options = OrderedDict([])
         if schema["type"] == "string":
             options["Fixed"] = StringFixedScanOption
+        elif schema["type"] == "bool":
+            options["Fixed"] = BoolFixedScanOption
         else:
             # TODO: Properly handle int, add errors (or default to PYON value).
             options["Fixed"] = FixedScanOption
@@ -726,6 +728,19 @@ class StringFixedScanOption(ScanOption):
 
     def set_value(self, value) -> None:
         self.box.setText(value)
+
+
+class BoolFixedScanOption(ScanOption):
+    def build_ui(self, layout: QtWidgets.QLayout) -> None:
+        self.box = QtWidgets.QCheckBox()
+        layout.addWidget(self.box)
+
+    def write_to_params(self, params: dict) -> None:
+        o = {"path": self.entry.path, "value": self.box.isChecked()}
+        params["overrides"].setdefault(self.entry.schema["fqn"], []).append(o)
+
+    def set_value(self, value) -> None:
+        self.box.setChecked(value)
 
 
 class NumericScanOption(ScanOption):

--- a/test/test_experiment_parameters.py
+++ b/test/test_experiment_parameters.py
@@ -1,5 +1,5 @@
 import unittest
-from ndscan.experiment.parameters import FloatParam, IntParam
+from ndscan.experiment.parameters import FloatParam, IntParam, BoolParam
 
 
 class FloatParamCase(unittest.TestCase):
@@ -38,4 +38,19 @@ class IntParamCase(unittest.TestCase):
                     "is_scannable": True,
                 },
                 "type": "int"
+            })
+
+
+class BoolParamCase(unittest.TestCase):
+    def test_describe(self):
+        param = BoolParam("foo", "bar", True)
+        self.assertEqual(
+            param.describe(), {
+                "fqn": "foo",
+                "description": "bar",
+                "type": "bool",
+                "default": "True",
+                "spec": {
+                    "is_scannable": True
+                }
             })


### PR DESCRIPTION
Create basic implementation of boolean parameters, for easy handling of boolean arguments by parent fragments and scanning over booleans (not implemented). 

UnitTests included.

In future, add scans over bool parameters and present the results in two separate graphs for `True` and `False` cases. Similarly, could implement Enum parameters.