### PR TITLE
experiment: Re-read param defaults in run phase

### DIFF
--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -380,6 +380,10 @@ class TopLevelRunner(HasEnvironment):
         self.num_current_underflows = 0
         try:
             while True:
+                # After every pause(), pull in dataset changes (immediately as well to
+                # catch changes between the time the experiment is prepared and when it
+                # is run, to keep the semantics uniform).
+                self.fragment.recompute_param_defaults()
                 try:
                     self.fragment.host_setup()
                     if is_kernel(self.fragment.run_once):
@@ -393,7 +397,6 @@ class TopLevelRunner(HasEnvironment):
                 finally:
                     self.fragment.host_cleanup()
                 self.scheduler.pause()
-                self.fragment.recompute_param_defaults()
         finally:
             self._set_completed()
 

--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -135,7 +135,7 @@ class ScanRunner(HasEnvironment):
     def _run_scan_on_core_device(self, fragment: ExpFragment, points: list,
                                  axes: List[ScanAxis],
                                  axis_sinks: List[ResultSink]) -> None:
-        # Stash away _ragment in member variable to pacify ARTIQ compiler; there is no
+        # Stash away fragment in member variable to pacify ARTIQ compiler; there is no
         # reason this shouldn't just be passed along and materialised as a global.
         self._kscan_fragment = fragment
 

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -219,3 +219,12 @@ class TwoAnalysisAggregate(AggregateExpFragment):
         self.setattr_param_rebind("a", self.first)
         self.second.bind_param("a", self.a)
         return super().build_fragment([self.first, self.second])
+
+
+class ReadParamDefault(ExpFragment):
+    def build_fragment(self):
+        self.setattr_param("foo", IntParam, "Foo", default="dataset('foo', 0)")
+        self.setattr_result("value", IntChannel)
+
+    def run_once(self) -> None:
+        self.value.push(self.foo.get())

--- a/test/test_experiment_entrypoint.py
+++ b/test/test_experiment_entrypoint.py
@@ -10,12 +10,13 @@ from sipyco import pyon
 from fixtures import (AddOneFragment, ReboundAddOneFragment, TrivialKernelFragment,
                       TransitoryErrorFragment, MultiPointTransitoryErrorFragment,
                       RequestTerminationFragment, AddOneAggregate,
-                      TrivialKernelAggregate, TwoAnalysisAggregate)
+                      TrivialKernelAggregate, TwoAnalysisAggregate, ReadParamDefault)
 from mock_environment import HasEnvironmentCase
 
 ScanAddOneExp = make_fragment_scan_exp(AddOneFragment)
 ScanReboundAddOneExp = make_fragment_scan_exp(ReboundAddOneFragment)
 ScanTwoAnalysisAggregateExp = make_fragment_scan_exp(TwoAnalysisAggregate)
+ScanReadParamDefaultExp = make_fragment_scan_exp(ReadParamDefault)
 
 
 class TestAggregateExpFragment(HasEnvironmentCase):
@@ -283,6 +284,18 @@ class FragmentScanExpCase(HasEnvironmentCase):
         results = json.loads(self.dataset_db.get("ndscan.rid_0.analysis_results"))
         self.assertTrue("first_result_a" in results)
         self.assertTrue("second_result_a" in results)
+
+    def test_recompute_param_defaults(self):
+        """Ensure dataset changes before run stage are reflected in defaults"""
+        self.dataset_db.data["foo"] = (True, 1)
+        exp = self.create(ScanReadParamDefaultExp)
+        exp.prepare()
+
+        self.dataset_db.data["foo"] = (True, 2)
+        exp.run()
+
+        print(self.dataset_db.data.keys())
+        self.assertEqual(self.dataset_db.data["ndscan.rid_0.point.value"][1], 2)
 
 
 class RunOnceCase(HasEnvironmentCase):


### PR DESCRIPTION
This catches dataset changes after the experiment has been
prepared to run. As we generally keep the defaults up to date
automatically after the experiment is paused, this should fit
the principle of least surprise.
