### PR TITLE
WIP: Add live analysis

### DIFF
--- a/ndscan/experiment/default_analysis.py
+++ b/ndscan/experiment/default_analysis.py
@@ -249,29 +249,6 @@ class CustomAnalysis(DefaultAnalysis):
         return [a.describe(context) for a in annotations]
 
 
-class LiveAnalysis(CustomAnalysis):
-    def execute(self,
-                axis_data: Dict[AxisIdentity, list],
-                result_data: Dict[ResultChannel, list],
-                ) -> List[Dict[str, Any]]:
-        user_axis_data = {}
-        for handle in self._required_axis_handles:
-            user_axis_data[handle] = axis_data[handle._store.identity]
-
-        try:
-            self._analyze_fn(user_axis_data,
-                             result_data,
-                             self._result_channels)
-        except TypeError as orignal_exception:
-            # Tolerate old analysis functions that do not take analysis result channels.
-            try:
-                self._analyze_fn(user_axis_data, result_data)
-            except TypeError:
-                # KLUDGE: If that also fails (e.g. there is a TypeError in the actual
-                # implementation), let the original exception bubble up.
-                raise orignal_exception
-
-
 #: Default points of interest for various fit types (e.g. highlighting the π time for a
 #: Rabi flop fit, or the extremum of a parabola.
 DEFAULT_FIT_ANNOTATIONS = {

--- a/ndscan/experiment/default_analysis.py
+++ b/ndscan/experiment/default_analysis.py
@@ -249,6 +249,29 @@ class CustomAnalysis(DefaultAnalysis):
         return [a.describe(context) for a in annotations]
 
 
+class LiveAnalysis(CustomAnalysis):
+    def execute(self,
+                axis_data: Dict[AxisIdentity, list],
+                result_data: Dict[ResultChannel, list],
+                ) -> List[Dict[str, Any]]:
+        user_axis_data = {}
+        for handle in self._required_axis_handles:
+            user_axis_data[handle] = axis_data[handle._store.identity]
+
+        try:
+            self._analyze_fn(user_axis_data,
+                             result_data,
+                             self._result_channels)
+        except TypeError as orignal_exception:
+            # Tolerate old analysis functions that do not take analysis result channels.
+            try:
+                self._analyze_fn(user_axis_data, result_data)
+            except TypeError:
+                # KLUDGE: If that also fails (e.g. there is a TypeError in the actual
+                # implementation), let the original exception bubble up.
+                raise orignal_exception
+
+
 #: Default points of interest for various fit types (e.g. highlighting the π time for a
 #: Rabi flop fit, or the extremum of a parabola.
 DEFAULT_FIT_ANNOTATIONS = {

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -241,6 +241,7 @@ class TopLevelRunner(HasEnvironment):
             # of style would intend.
             dataset_prefix += "."
         self.dataset_prefix = dataset_prefix
+        self.fragment.dataset_prefix = self.dataset_prefix
 
         # FIXME: We save these as individual booleans as enums crash the ARTIQ compiler.
         self._continue_running = False
@@ -334,6 +335,9 @@ class TopLevelRunner(HasEnvironment):
                                      self.dataset_prefix + "points.axis_{}".format(i))
                 for i in range(len(self.spec.axes))
             ]
+            self.fragment.register_live_analyses(self.spec.axes,
+                                             self._coordinate_sinks,
+                                             self._scan_result_sinks)
             runner.run(self.fragment, self.spec, self._coordinate_sinks)
             self._set_completed()
 

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import logging
 from typing import Any, Dict, List, Iterable, Type, Tuple, Optional
 
-from .default_analysis import DefaultAnalysis, ResultPrefixAnalysisWrapper
+from .default_analysis import DefaultAnalysis, LiveAnalysis, ResultPrefixAnalysisWrapper
 from .parameters import ParamHandle, ParamStore
 from .result_channels import ResultChannel, FloatChannel
 from .utils import is_kernel, path_matches_spec
@@ -706,6 +706,70 @@ class ExpFragment(Fragment):
         This is a class method in spirit, and might become one in the future.
         """
         return []
+
+    def get_live_analyses(self) -> List[LiveAnalysis]:
+        return []
+
+    def register_live_analyses(
+        self,
+        axes=[],
+        coordinate_sinks=[],
+        scan_result_sinks: dict = {},
+    ):
+        """Filter analyses for specific scan and store"""
+        analyses = self.get_live_analyses()
+        self._analyses = filter_live_analyses(analyses, axes)
+        self._axes = axes
+        self._coordinate_sinks = coordinate_sinks
+        self._scan_result_sinks = scan_result_sinks
+
+    def _make_coordinate_dict(self):
+        """Copy paste from entry_point/TopLevelRunner._make_coordinate_dict
+        (ran into an import loop I didn't have the brain power to fix)"""
+        return OrderedDict(
+            ((a.param_schema["fqn"], a.path), s.get_all())
+            for a, s in zip(self._axes, self._coordinate_sinks)
+        )
+
+    def _make_value_dict(self):
+        """Copy paste from entry_point/TopLevelRunner._make_value_dict
+        (ran into an import loop I didn't have the brain power to fix)"""
+        return {c: s.get_all() for c, s in self._scan_result_sinks.items()}
+
+    @rpc(flags={"async"})
+    def live_analyses(self):
+        """Minimal implementation of entry_point/TopLevelRunner.analyze
+        Purely for data processing, does not handle annotations (yet!)"""
+        coordinates = self._make_coordinate_dict()
+        values = self._make_value_dict()
+        for a in self._analyses:
+            a.execute(coordinates, values)
+
+
+def filter_live_analyses(analyses: List[LiveAnalysis], axes) -> List[LiveAnalysis]:
+    """Copy of scan_runner.filter_default_analyses
+    (ran into an import loop I didn't have the brain power to fix)"""
+    ax = list(axes)  # Don't exhaust an arbitrary iterable.
+    result = []
+    for a in analyses:
+        if not isinstance(a, LiveAnalysis):
+            raise ValueError(
+                f"Unexpected get_default_analyses() return value for {a}: "
+                "Expected list of ndscan.experiment.DefaultAnalysis instances, got "
+                f"element of type '{a}'"
+            )
+        if match_default_analysis(a, ax):
+            result.append(a)
+    return result
+
+
+def match_default_analysis(analysis: LiveAnalysis, axes) -> bool:
+    """Copy of scan_runner.filter_default_analyses
+    (ran into an import loop I didn't have the brain power to fix)
+    """
+    stores = set(a.param_store for a in axes)
+    assert None not in stores, "Can only match analyses after stores have been created"
+    return set(a._store for a in analysis.required_axes()) == stores
 
 
 def _skip_common_prefix(target: list, reference: list) -> list:

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import logging
 from typing import Any, Dict, List, Iterable, Type, Tuple, Optional
 
-from .default_analysis import DefaultAnalysis, LiveAnalysis, ResultPrefixAnalysisWrapper
+from .default_analysis import DefaultAnalysis, ResultPrefixAnalysisWrapper
 from .parameters import ParamHandle, ParamStore
 from .result_channels import ResultChannel, FloatChannel
 from .utils import is_kernel, path_matches_spec
@@ -707,70 +707,8 @@ class ExpFragment(Fragment):
         """
         return []
 
-    def get_live_analyses(self) -> List[LiveAnalysis]:
+    def get_live_analyses(self) -> List[DefaultAnalysis]:
         return []
-
-    def register_live_analyses(
-        self,
-        axes=[],
-        coordinate_sinks=[],
-        scan_result_sinks: dict = {},
-    ):
-        """Filter analyses for specific scan and store"""
-        analyses = self.get_live_analyses()
-        self._analyses = filter_live_analyses(analyses, axes)
-        self._axes = axes
-        self._coordinate_sinks = coordinate_sinks
-        self._scan_result_sinks = scan_result_sinks
-
-    def _make_coordinate_dict(self):
-        """Copy paste from entry_point/TopLevelRunner._make_coordinate_dict
-        (ran into an import loop I didn't have the brain power to fix)"""
-        return OrderedDict(
-            ((a.param_schema["fqn"], a.path), s.get_all())
-            for a, s in zip(self._axes, self._coordinate_sinks)
-        )
-
-    def _make_value_dict(self):
-        """Copy paste from entry_point/TopLevelRunner._make_value_dict
-        (ran into an import loop I didn't have the brain power to fix)"""
-        return {c: s.get_all() for c, s in self._scan_result_sinks.items()}
-
-    @rpc(flags={"async"})
-    def live_analyses(self):
-        """Minimal implementation of entry_point/TopLevelRunner.analyze
-        Purely for data processing, does not handle annotations (yet!)"""
-        coordinates = self._make_coordinate_dict()
-        values = self._make_value_dict()
-        for a in self._analyses:
-            a.execute(coordinates, values)
-
-
-def filter_live_analyses(analyses: List[LiveAnalysis], axes) -> List[LiveAnalysis]:
-    """Copy of scan_runner.filter_default_analyses
-    (ran into an import loop I didn't have the brain power to fix)"""
-    ax = list(axes)  # Don't exhaust an arbitrary iterable.
-    result = []
-    for a in analyses:
-        if not isinstance(a, LiveAnalysis):
-            raise ValueError(
-                f"Unexpected get_default_analyses() return value for {a}: "
-                "Expected list of ndscan.experiment.DefaultAnalysis instances, got "
-                f"element of type '{a}'"
-            )
-        if match_default_analysis(a, ax):
-            result.append(a)
-    return result
-
-
-def match_default_analysis(analysis: LiveAnalysis, axes) -> bool:
-    """Copy of scan_runner.filter_default_analyses
-    (ran into an import loop I didn't have the brain power to fix)
-    """
-    stores = set(a.param_store for a in axes)
-    assert None not in stores, "Can only match analyses after stores have been created"
-    return set(a._store for a in analysis.required_axes()) == stores
-
 
 def _skip_common_prefix(target: list, reference: list) -> list:
     i = 0

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -151,6 +151,11 @@ class ResultChannel:
     def __repr__(self) -> str:
         return "<{}@{}: {}>".format(type(self).__name__, hex(id(self)), self.path)
 
+    def get_dataset_path(self):
+        if self.sink:
+            return self.sink.key
+        return None
+
     def describe(self) -> Dict[str, Any]:
         """
         """

--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -19,8 +19,12 @@ from .scan_generator import generate_points, ScanGenerator, ScanOptions
 from .utils import is_kernel
 
 __all__ = [
-    "ScanAxis", "ScanSpec", "ScanRunner", "filter_default_analyses", "describe_scan",
-    "describe_analyses"
+    "ScanAxis",
+    "ScanSpec",
+    "ScanRunner",
+    "filter_default_analyses",
+    "describe_scan",
+    "describe_analyses",
 ]
 
 
@@ -31,8 +35,10 @@ class ScanAxis:
     scan at runtime; i.e. the :class:`.ParamStore` to modify in order to set the
     parameter.
     """
-    def __init__(self, param_schema: Dict[str, Any], path: str,
-                 param_store: ParamStore):
+
+    def __init__(
+        self, param_schema: Dict[str, Any], path: str, param_store: ParamStore
+    ):
         self.param_schema = param_schema
         self.path = path
         self.param_store = param_store
@@ -45,8 +51,13 @@ class ScanSpec:
     :param generators: Generators that give the points for each of the specified axes.
     :param options: Applicable :class:`.ScanOptions`.
     """
-    def __init__(self, axes: List[ScanAxis], generators: List[ScanGenerator],
-                 options: ScanOptions):
+
+    def __init__(
+        self,
+        axes: List[ScanAxis],
+        generators: List[ScanGenerator],
+        options: ScanOptions,
+    ):
         self.axes = axes
         self.generators = generators
         self.options = options
@@ -66,9 +77,11 @@ class ScanRunner(HasEnvironment):
     # metaprogramming. While the interface for this class is effortlessly generic, the
     # implementation might well be a long-forgotten ritual for invoking Cthulhu.
 
-    def build(self,
-              max_rtio_underflow_retries: int = 3,
-              max_transitory_error_retries: int = 10):
+    def build(
+        self,
+        max_rtio_underflow_retries: int = 3,
+        max_transitory_error_retries: int = 10,
+    ):
         """
         :param max_rtio_underflow_retries: Number of RTIOUnderflows to tolerate per scan
             point (by simply trying again) before giving up.
@@ -80,8 +93,9 @@ class ScanRunner(HasEnvironment):
         self.setattr_device("core")
         self.setattr_device("scheduler")
 
-    def run(self, fragment: ExpFragment, spec: ScanSpec,
-            axis_sinks: List[ResultSink]) -> None:
+    def run(
+        self, fragment: ExpFragment, spec: ScanSpec, axis_sinks: List[ResultSink]
+    ) -> None:
         """Run a scan of the given fragment, with axes as specified.
 
         :param fragment: The fragment to iterate.
@@ -93,12 +107,20 @@ class ScanRunner(HasEnvironment):
         points = generate_points(spec.generators, spec.options)
 
         # TODO: Support parameters which require host_setup() when changed.
-        run_impl = self._run_scan_on_core_device if is_kernel(
-            fragment.run_once) else self._run_scan_on_host
+        run_impl = (
+            self._run_scan_on_core_device
+            if is_kernel(fragment.run_once)
+            else self._run_scan_on_host
+        )
         run_impl(fragment, points, spec.axes, axis_sinks)
 
-    def _run_scan_on_host(self, fragment: ExpFragment, points: Iterator[Tuple],
-                          axes: List[ScanAxis], axis_sinks: List[ResultSink]) -> None:
+    def _run_scan_on_host(
+        self,
+        fragment: ExpFragment,
+        points: Iterator[Tuple],
+        axes: List[ScanAxis],
+        axis_sinks: List[ResultSink],
+    ) -> None:
         while True:
             # After every pause(), pull in dataset changes (immediately as well to catch
             # changes between the time the experiment is prepared and when it is run, to
@@ -116,6 +138,7 @@ class ScanRunner(HasEnvironment):
                             sink.push(value)
                         fragment.device_setup()
                         fragment.run_once()
+                        fragment.live_analyses()
                         if self.scheduler.check_pause():
                             break
                 finally:
@@ -132,9 +155,13 @@ class ScanRunner(HasEnvironment):
                 self.core.close()
             self.scheduler.pause()
 
-    def _run_scan_on_core_device(self, fragment: ExpFragment, points: list,
-                                 axes: List[ScanAxis],
-                                 axis_sinks: List[ResultSink]) -> None:
+    def _run_scan_on_core_device(
+        self,
+        fragment: ExpFragment,
+        points: list,
+        axes: List[ScanAxis],
+        axis_sinks: List[ResultSink],
+    ) -> None:
         # Stash away fragment in member variable to pacify ARTIQ compiler; there is no
         # reason this shouldn't just be passed along and materialised as a global.
         self._kscan_fragment = fragment
@@ -159,11 +186,12 @@ class ScanRunner(HasEnvironment):
         # the concrete type for this scan so the compiler can infer the types in
         # run_chunk() correctly.
         self._kscan_param_values_chunk.__func__.__annotations__ = {
-            "return":
-            TTuple([
-                TList(type_string_to_param(a.param_schema["type"]).CompilerType)
-                for a in axes
-            ])
+            "return": TTuple(
+                [
+                    TList(type_string_to_param(a.param_schema["type"]).CompilerType)
+                    for a in axes
+                ]
+            )
         }
 
         # Build kernel function that calls _kscan_param_values_chunk() and iterates over
@@ -174,8 +202,9 @@ class ScanRunner(HasEnvironment):
         # express indexing or deconstructing a tuple of values of inhomogeneous types
         # without actually writing it out as an assignment from a tuple value.
         for i, axis in enumerate(axes):
-            setattr(self, "_kscan_param_setter_{}".format(i),
-                    axis.param_store.set_value)
+            setattr(
+                self, "_kscan_param_setter_{}".format(i), axis.param_store.set_value
+            )
         run_chunk = self._build_kscan_run_chunk(len(axes))
 
         self._kscan_update_host_param_stores()
@@ -234,8 +263,9 @@ class ScanRunner(HasEnvironment):
             if self._kscan_should_pause():
                 return True
             try:
-                self._kscan_fragment.device_setup()
-                self._kscan_fragment.run_once()
+                self._fragment.device_setup()
+                self._fragment.run_once()
+                self._fragment.live_analyses()
                 break
             except RTIOUnderflow:
                 # For the first two underflows per point, just print a warning and carry
@@ -245,8 +275,13 @@ class ScanRunner(HasEnvironment):
                 if num_underflows >= self.max_rtio_underflow_retries:
                     raise
                 num_underflows += 1
-                print("Ignoring RTIOUnderflow (", num_underflows, "/",
-                      self.max_rtio_underflow_retries, ")")
+                print(
+                    "Ignoring RTIOUnderflow (",
+                    num_underflows,
+                    "/",
+                    self.max_rtio_underflow_retries,
+                    ")",
+                )
                 self._kscan_retry_point()
             except RestartKernelTransitoryError:
                 print("Caught transitory error, restarting kernel")
@@ -256,8 +291,13 @@ class ScanRunner(HasEnvironment):
                 if num_transitory_errors >= self.max_transitory_error_retries:
                     raise
                 num_transitory_errors += 1
-                print("Caught transitory error (", num_transitory_errors, "/",
-                      self.max_transitory_error_retries, "), retrying")
+                print(
+                    "Caught transitory error (",
+                    num_transitory_errors,
+                    "/",
+                    self.max_transitory_error_retries,
+                    "), retrying",
+                )
                 self._kscan_retry_point()
         self._kscan_point_completed()
         return False
@@ -265,8 +305,10 @@ class ScanRunner(HasEnvironment):
     @kernel
     def _kscan_should_pause(self) -> TBool:
         current_time_mu = self.core.get_rtio_counter_mu()
-        if (current_time_mu - self._kscan_last_pause_check_mu >
-                self._kscan_pause_check_interval_mu):
+        if (
+            current_time_mu - self._kscan_last_pause_check_mu
+            > self._kscan_pause_check_interval_mu
+        ):
             self._kscan_last_pause_check_mu = current_time_mu
             if self.scheduler.check_pause():
                 return True
@@ -282,7 +324,8 @@ class ScanRunner(HasEnvironment):
         CHUNK_SIZE = 10
 
         self._kscan_current_chunk.extend(
-            islice(self._kscan_points, CHUNK_SIZE - len(self._kscan_current_chunk)))
+            islice(self._kscan_points, CHUNK_SIZE - len(self._kscan_current_chunk))
+        )
 
         values = tuple([] for _ in self._kscan_axes)
         for p in self._kscan_current_chunk:
@@ -353,8 +396,9 @@ def match_default_analysis(analysis: DefaultAnalysis, axes: Iterable[ScanAxis]) 
     return set(a._store for a in analysis.required_axes()) == stores
 
 
-def filter_default_analyses(fragment: ExpFragment,
-                            axes: Iterable[ScanAxis]) -> List[DefaultAnalysis]:
+def filter_default_analyses(
+    fragment: ExpFragment, axes: Iterable[ScanAxis]
+) -> List[DefaultAnalysis]:
     """Return the default analyses of the given fragment that can be executed for the
     given scan spec.
 
@@ -367,14 +411,16 @@ def filter_default_analyses(fragment: ExpFragment,
             raise ValueError(
                 f"Unexpected get_default_analyses() return value for {fragment}: "
                 "Expected list of ndscan.experiment.DefaultAnalysis instances, got "
-                f"element of type '{analysis}'")
+                f"element of type '{analysis}'"
+            )
         if match_default_analysis(analysis, ax):
             result.append(analysis)
     return result
 
 
-def describe_scan(spec: ScanSpec, fragment: ExpFragment,
-                  short_result_names: Dict[ResultChannel, str]) -> Dict[str, Any]:
+def describe_scan(
+    spec: ScanSpec, fragment: ExpFragment, short_result_names: Dict[ResultChannel, str]
+) -> Dict[str, Any]:
     """Return metadata for the given spec in stringly typed dictionary form.
 
     :param spec: :class:`.ScanSpec` describing the scan.
@@ -384,10 +430,13 @@ def describe_scan(spec: ScanSpec, fragment: ExpFragment,
     desc = {}
 
     desc["fragment_fqn"] = fragment.fqn
-    axis_specs = [{
-        "param": ax.param_schema,
-        "path": ax.path,
-    } for ax in spec.axes]
+    axis_specs = [
+        {
+            "param": ax.param_schema,
+            "path": ax.path,
+        }
+        for ax in spec.axes
+    ]
     for ax, gen in zip(axis_specs, spec.generators):
         gen.describe_limits(ax)
 
@@ -398,14 +447,16 @@ def describe_scan(spec: ScanSpec, fragment: ExpFragment,
     # them; they should possibly just be ignored there.
     desc["channels"] = {
         name: channel.describe()
-        for (channel, name) in short_result_names.items() if channel.save_by_default
+        for (channel, name) in short_result_names.items()
+        if channel.save_by_default
     }
 
     return desc
 
 
-def describe_analyses(analyses: Iterable[DefaultAnalysis],
-                      context: AnnotationContext) -> Dict[str, Any]:
+def describe_analyses(
+    analyses: Iterable[DefaultAnalysis], context: AnnotationContext
+) -> Dict[str, Any]:
     """Return metadata for the given analyses in stringly typed dictionary form.
 
     :param analyses: The :class:`.DefaultAnalysis` objects to describe (already filtered
@@ -426,6 +477,7 @@ def describe_analyses(analyses: Iterable[DefaultAnalysis],
         for name, spec in online_analyses.items():
             if name in desc["online_analyses"]:
                 raise ValueError(
-                    "An online analysis with name '{}' already exists".format(name))
+                    "An online analysis with name '{}' already exists".format(name)
+                )
             desc["online_analyses"][name] = spec
     return desc

--- a/ndscan/experiment/utils.py
+++ b/ndscan/experiment/utils.py
@@ -1,6 +1,6 @@
 import json
 import numpy
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, OrderedDict
 
 
 def path_matches_spec(path: Iterable[str], spec: str) -> bool:
@@ -55,3 +55,14 @@ def to_metadata_broadcast_type(obj: Any) -> Optional[Any]:
     if isinstance(obj, int) or isinstance(obj, float) or isinstance(obj, str):
         return obj
     return None
+
+
+def make_coordinate_dict(axes, coordinate_sinks):
+    return OrderedDict(
+        ((a.param_schema["fqn"], a.path), s.get_all())
+        for a, s in zip(axes, coordinate_sinks)
+    )
+
+
+def make_value_dict(scan_result_sinks: dict):
+    return {c: s.get_all() for c, s in scan_result_sinks.items()}


### PR DESCRIPTION
### This is ~~very~~ hacky - just showing how something like this could look. 
### Code needs tidying ~~and removing a bunch of copy pastes!~~

~~Add LiveAnalysis~~

~~This is similar to DefaultAnalysis, but with a stripped back implementation to handle only reading result channels and pushing to other datasets~~

Adds LiveAnalysisRunner, which handles the live_analysis passed from `ExpFragment.get_live_analyses`
The required CustomAnalysis classes are determined at build time through similar filters 

A change that is worth discussion, at run time the `dataset_prefix` is passed from the `TopLevelRunner` to the fragment. This allows the fragment to access datasets at run time which is very useful for the live analysis.

~~Most of the changes to `Fragment` stem from  the `ScanRunner` not having access to the `TopLevelRunner`. For the `DefaultAnalysis` this is run after the `ScanRunner` is done and so isn't an issue.~~

~~We could pass the `TopLevelRunner` as an argument to `ScanRunner.run` and then call the `live_analysis` on `TopLevelRunner`.~~

Alternatively (and perhaps most sensibly) we pass the `LiveAnalysis` objects down to the `ScanRunner` and have `ScanRunner` handle them. **- Have done this through the LiveAnalysisRunner**

Of course, this is all assuming we want to stick with a model roughly like the `LiveAnalysis`