### PR TITLE
docs: Fix path to custom CSS

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,7 @@ html_context = {
     'conf_py_path': '/docs/',
 }
 
-html_css_files = ['_static/theme_overrides.css']  # override wide tables in RTD theme
+html_css_files = ['theme_overrides.css']  # override wide tables in RTD theme
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
This fixes up a5231415fb3d02ad3a78b3724789537dd45a4278;
apparently, Sphinx prepends the static file path to html_css_files.
