### PR TITLE
Bulk-update to streamlined type hint syntax

### DIFF
--- a/ndscan/applet.py
+++ b/ndscan/applet.py
@@ -7,8 +7,9 @@ from artiq.applets.simple import SimpleApplet
 import argparse
 import logging
 import pyqtgraph
+from collections.abc import Iterable
 from sipyco import common_args
-from typing import Any, Dict, Iterable
+from typing import Any
 
 from .plots.container_widgets import RootWidget
 from .plots.model import Context
@@ -34,8 +35,8 @@ class _MainWidget(RootWidget):
         self.resize(600, 600)
         self.setWindowTitle("ndscan plot")
 
-    def data_changed(self, values: Dict[str, Any], metadata: Dict[str, Any],
-                     persist: Dict[str, bool], mods: Iterable[Dict[str, Any]]):
+    def data_changed(self, values: dict[str, Any], metadata: dict[str, Any],
+                     persist: dict[str, bool], mods: Iterable[dict[str, Any]]):
         self.root.data_changed(values, mods)
 
 

--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -4,7 +4,7 @@ from enum import Enum, unique
 from functools import partial
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 from artiq.dashboard.experiments import _WheelFilter
 from artiq.gui.entries import procdesc_to_entry
 from artiq.gui.fuzzy_select import FuzzySelectWidget
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def _try_extract_ndscan_params(
-        arguments: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], Dict[str, Any]]:
+        arguments: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[str, Any]]:
     """From a passed dictionary of upstream ARTIQ arguments, extracts the ndscan
     arguments, if there are any.
 
@@ -47,7 +47,7 @@ def _update_ndscan_params(arguments, params):
 
 
 class ScanOptions:
-    def __init__(self, current_scan: Dict[str, Any]):
+    def __init__(self, current_scan: dict[str, Any]):
         self.num_repeats_container = QtWidgets.QWidget()
         num_repeats_layout = QtWidgets.QHBoxLayout()
         self.num_repeats_container.setLayout(num_repeats_layout)
@@ -126,13 +126,13 @@ class ScanOptions:
         skip_persistently_failing_layout.setStretchFactor(
             self.skip_persistently_failing_box, 1)
 
-    def get_widgets(self) -> List[QtWidgets.QWidget]:
+    def get_widgets(self) -> list[QtWidgets.QWidget]:
         return [
             self.num_repeats_container, self.no_axis_container,
             self.randomise_globally_container, self.skip_persistently_failing_container
         ]
 
-    def write_to_params(self, params: Dict[str, Any]) -> None:
+    def write_to_params(self, params: dict[str, Any]) -> None:
         scan = params.setdefault("scan", {})
         scan["num_repeats"] = self.num_repeats_box.value()
         scan["no_axes_mode"] = NoAxesMode(self.no_axes_box.currentText()).name
@@ -713,7 +713,7 @@ class OverrideEntry(LayoutWidget):
         self.current_option_idx = new_idx
 
 
-def _parse_list_pyon(values: str) -> List[float]:
+def _parse_list_pyon(values: str) -> list[float]:
     return pyon.decode("[" + values + "]")
 
 

--- a/ndscan/dataset_janitor.py
+++ b/ndscan/dataset_janitor.py
@@ -17,7 +17,6 @@ import argparse
 import asyncio
 import logging
 import time
-from typing import Optional
 from sipyco import common_args, pc_rpc, sync_struct
 
 logger = logging.getLogger(__name__)
@@ -90,10 +89,10 @@ async def run(args):
     #: or something went wrong with one of the connections.
     wake_loop = asyncio.Event()
 
-    dataset_db: Optional[pc_rpc.AsyncioClient] = None
-    dataset_sub: Optional[sync_struct.Subscriber] = None
+    dataset_db: pc_rpc.AsyncioClient | None = None
+    dataset_sub: sync_struct.Subscriber | None = None
     dataset_sub_broken: bool = False
-    schedule_sub: Optional[sync_struct.Subscriber] = None
+    schedule_sub: sync_struct.Subscriber | None = None
     schedule_sub_broken: bool = False
 
     def all_connected():

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -10,7 +10,7 @@
 
 from artiq.language import *
 from artiq.language import units
-from typing import Any, Dict, Optional, Tuple, Type, Union
+from typing import Any
 from ..utils import eval_param_default, GetDataset
 
 __all__ = ["FloatParam", "IntParam", "StringParam", "BoolParam"]
@@ -29,7 +29,6 @@ def type_string_to_param(name: str):
 class InvalidDefaultError(ValueError):
     """Raised when a default value is outside the specified range of valid parameter
     values."""
-    pass
 
 
 class ParamStore:
@@ -38,7 +37,7 @@ class ParamStore:
         store, i.e. the override/default value it was created for.
     :param value: The initial value.
     """
-    def __init__(self, identity: Tuple[str, str], value):
+    def __init__(self, identity: tuple[str, str], value):
         self.identity = identity
 
         # KLUDGE: To work around ARTIQ compiler type inference failing for empty lists,
@@ -179,7 +178,7 @@ class ParamHandle:
     :param name: The name of the attribute in the owning fragment bound to this
         object.
     """
-    def __init__(self, owner: Type["Fragment"], name: str):
+    def __init__(self, owner: type["Fragment"], name: str):
         self.owner = owner
         self.name = name
         assert name.isidentifier(), ("ParamHandle name should be the identifier it is "
@@ -249,7 +248,7 @@ class BoolParamHandle(ParamHandle):
         return self._store.get_value()
 
 
-def resolve_numeric_scale(scale: Optional[float], unit: str) -> float:
+def resolve_numeric_scale(scale: float | None, unit: str) -> float:
     if scale is not None:
         return scale
     if unit == "":
@@ -277,13 +276,13 @@ class FloatParam(ParamBase):
     def __init__(self,
                  fqn: str,
                  description: str,
-                 default: Union[str, float],
+                 default: str | float,
                  *,
-                 min: Optional[float] = None,
-                 max: Optional[float] = None,
+                 min: float | None = None,
+                 max: float | None = None,
                  unit: str = "",
-                 scale: Optional[float] = None,
-                 step: Optional[float] = None,
+                 scale: float | None = None,
+                 step: float | None = None,
                  is_scannable: bool = True):
 
         ParamBase.__init__(self,
@@ -299,7 +298,7 @@ class FloatParam(ParamBase):
         self.scale = resolve_numeric_scale(scale, unit)
         self.step = step if step is not None else self.scale / 10.0
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         spec = {
             "is_scannable": self.is_scannable,
             "scale": self.scale,
@@ -325,7 +324,7 @@ class FloatParam(ParamBase):
             return eval_param_default(self.default, get_dataset)
         return self.default
 
-    def make_store(self, identity: Tuple[str, str], value: float) -> FloatParamStore:
+    def make_store(self, identity: tuple[str, str], value: float) -> FloatParamStore:
         if self.min is not None and value < self.min:
             raise InvalidDefaultError(
                 f"Value {value} for parameter {self.fqn} below minimum of {self.min}")
@@ -343,12 +342,12 @@ class IntParam(ParamBase):
     def __init__(self,
                  fqn: str,
                  description: str,
-                 default: Union[str, int],
+                 default: str | int,
                  *,
-                 min: Optional[int] = 0,
-                 max: Optional[int] = None,
+                 min: int | None = 0,
+                 max: int | None = None,
                  unit: str = "",
-                 scale: Optional[int] = None,
+                 scale: int | None = None,
                  is_scannable: bool = True):
 
         ParamBase.__init__(self,
@@ -367,7 +366,7 @@ class IntParam(ParamBase):
 
         self.is_scannable = is_scannable
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         spec = {"is_scannable": self.is_scannable, "scale": self.scale}
         if self.min is not None:
             spec["min"] = self.min
@@ -388,7 +387,7 @@ class IntParam(ParamBase):
             return eval_param_default(self.default, get_dataset)
         return self.default
 
-    def make_store(self, identity: Tuple[str, str], value: int) -> IntParamStore:
+    def make_store(self, identity: tuple[str, str], value: int) -> IntParamStore:
         if self.min is not None and value < self.min:
             raise InvalidDefaultError(
                 f"Value {value} for parameter {self.fqn} below minimum of {self.min}")
@@ -416,7 +415,7 @@ class StringParam(ParamBase):
                            default=default,
                            is_scannable=is_scannable)
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "fqn": self.fqn,
             "description": self.description,
@@ -430,7 +429,7 @@ class StringParam(ParamBase):
     def eval_default(self, get_dataset: GetDataset) -> str:
         return eval_param_default(self.default, get_dataset)
 
-    def make_store(self, identity: Tuple[str, str], value: str) -> StringParamStore:
+    def make_store(self, identity: tuple[str, str], value: str) -> StringParamStore:
         return StringParamStore(identity, value)
 
 
@@ -442,14 +441,14 @@ class BoolParam:
     def __init__(self,
                  fqn: str,
                  description: str,
-                 default: Union[str, bool],
+                 default: str | bool,
                  is_scannable: bool = True):
         self.fqn = fqn
         self.description = description
         self.default = default
         self.is_scannable = is_scannable
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "fqn": self.fqn,
             "description": self.description,
@@ -465,5 +464,5 @@ class BoolParam:
             return eval_param_default(self.default, get_dataset)
         return self.default
 
-    def make_store(self, identity: Tuple[str, str], value: bool) -> BoolParamStore:
+    def make_store(self, identity: tuple[str, str], value: bool) -> BoolParamStore:
         return BoolParamStore(identity, value)

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -4,7 +4,7 @@ Result handling building blocks.
 
 from artiq.language import HasEnvironment, rpc
 import artiq.language.units
-from typing import Any, Dict, List, Optional
+from typing import Any
 from .utils import dump_json
 
 __all__ = [
@@ -82,7 +82,7 @@ class ArraySink(ResultSink):
     def push(self, value: Any) -> None:
         self.data.append(value)
 
-    def get_all(self) -> List[Any]:
+    def get_all(self) -> list[Any]:
         """Return a list of all previously pushed values."""
         return self.data
 
@@ -118,7 +118,7 @@ class AppendingDatasetSink(ResultSink, HasEnvironment):
         """Return the last pushed value (or None)."""
         return self.last_value
 
-    def get_all(self) -> List[Any]:
+    def get_all(self) -> list[Any]:
         """Read back the previously pushed values from the target dataset (if any)."""
         return [] if (self.last_value is None) else self.get_dataset(self.key)
 
@@ -191,7 +191,7 @@ class ResultChannel:
     def __init__(self,
                  path: str,
                  description: str = "",
-                 display_hints: Optional[Dict[str, Any]] = None,
+                 display_hints: dict[str, Any] | None = None,
                  save_by_default: bool = True):
         self.path = path
         self.description = description
@@ -200,9 +200,9 @@ class ResultChannel:
         self.sink = None
 
     def __repr__(self) -> str:
-        return "<{}@{}: {}>".format(type(self).__name__, hex(id(self)), self.path)
+        return f"<{type(self).__name__}@{hex(id(self))}: {self.path}>"
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         """
         """
         desc = {
@@ -256,7 +256,7 @@ class NumericChannel(ResultChannel):
     def __init__(self,
                  path: str,
                  description: str = "",
-                 display_hints: Optional[Dict[str, Any]] = None,
+                 display_hints: dict[str, Any] | None = None,
                  min=None,
                  max=None,
                  unit: str = "",
@@ -277,7 +277,7 @@ class NumericChannel(ResultChannel):
         self.scale = scale
         self.unit = unit
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         """"""
         result = super().describe()
         result["scale"] = self.scale

--- a/ndscan/experiment/scan_generator.py
+++ b/ndscan/experiment/scan_generator.py
@@ -1,8 +1,9 @@
+from collections.abc import Iterator
 from dataclasses import dataclass
 from itertools import product
 import numpy as np
 import random
-from typing import Any, Dict, List, Iterator
+from typing import Any
 
 __all__ = [
     "ScanGenerator", "RefiningGenerator", "LinearGenerator", "ListGenerator",
@@ -18,12 +19,12 @@ class ScanGenerator:
         """
         raise NotImplementedError
 
-    def points_for_level(self, level: int, rng=None) -> List[Any]:
+    def points_for_level(self, level: int, rng=None) -> list[Any]:
         """
         """
         raise NotImplementedError
 
-    def describe_limits(self, target: Dict[str, Any]) -> None:
+    def describe_limits(self, target: dict[str, Any]) -> None:
         """
         """
         raise NotImplementedError
@@ -43,7 +44,7 @@ class RefiningGenerator(ScanGenerator):
         # out of points. Will need to be amended for integer parameters.
         return True
 
-    def points_for_level(self, level: int, rng=None) -> List[Any]:
+    def points_for_level(self, level: int, rng=None) -> list[Any]:
         ""
         if level == 0:
             return [self.lower, self.upper]
@@ -57,7 +58,7 @@ class RefiningGenerator(ScanGenerator):
 
         return points
 
-    def describe_limits(self, target: Dict[str, Any]) -> None:
+    def describe_limits(self, target: dict[str, Any]) -> None:
         ""
         target["min"] = self.lower
         target["max"] = self.upper
@@ -98,7 +99,7 @@ class ExpandingGenerator(ScanGenerator):
 
         return level <= max(num_points(self.limit_lower), num_points(self.limit_upper))
 
-    def points_for_level(self, level: int, rng=None) -> List[Any]:
+    def points_for_level(self, level: int, rng=None) -> list[Any]:
         ""
         if level == 0:
             return [self.centre]
@@ -116,7 +117,7 @@ class ExpandingGenerator(ScanGenerator):
             rng.shuffle(points)
         return points
 
-    def describe_limits(self, target: Dict[str, Any]) -> None:
+    def describe_limits(self, target: dict[str, Any]) -> None:
         ""
         if self.limit_lower > float("-inf"):
             target["min"] = self.limit_lower
@@ -139,7 +140,7 @@ class LinearGenerator(ScanGenerator):
         ""
         return level == 0
 
-    def points_for_level(self, level: int, rng=None) -> List[Any]:
+    def points_for_level(self, level: int, rng=None) -> list[Any]:
         ""
         assert level == 0
         points = np.linspace(start=self.start,
@@ -150,7 +151,7 @@ class LinearGenerator(ScanGenerator):
             rng.shuffle(points)
         return points.tolist()
 
-    def describe_limits(self, target: Dict[str, Any]) -> None:
+    def describe_limits(self, target: dict[str, Any]) -> None:
         ""
         target["min"] = min(self.start, self.stop)
         target["max"] = max(self.start, self.stop)
@@ -200,7 +201,7 @@ class ListGenerator(ScanGenerator):
         ""
         return level == 0
 
-    def points_for_level(self, level: int, rng=None) -> List[Any]:
+    def points_for_level(self, level: int, rng=None) -> list[Any]:
         ""
         assert level == 0
         values = self.values
@@ -209,7 +210,7 @@ class ListGenerator(ScanGenerator):
             rng.shuffle(values)
         return values
 
-    def describe_limits(self, target: Dict[str, Any]) -> None:
+    def describe_limits(self, target: dict[str, Any]) -> None:
         ""
         values = np.array(self.values)
         if np.issubdtype(values.dtype, np.number):
@@ -255,7 +256,7 @@ class ScanOptions:
             self.seed = random.getrandbits(32)
 
 
-def generate_points(axis_generators: List[ScanGenerator],
+def generate_points(axis_generators: list[ScanGenerator],
                     options: ScanOptions) -> Iterator[Any]:
     rng = np.random.RandomState(options.seed)
 

--- a/ndscan/experiment/subscan.py
+++ b/ndscan/experiment/subscan.py
@@ -6,7 +6,6 @@ another child fragment as part of its execution.
 from collections import OrderedDict
 from copy import copy
 from functools import reduce
-from typing import Dict, List, Tuple, Union
 from artiq.language import kernel, portable, rpc
 from .default_analysis import AnnotationContext, DefaultAnalysis
 from .fragment import ExpFragment, Fragment, RestartKernelTransitoryError
@@ -30,14 +29,14 @@ class Subscan:
         self,
         runner: ScanRunner,
         fragment: ExpFragment,
-        possible_axes: Dict[ParamHandle, ScanAxis],
+        possible_axes: dict[ParamHandle, ScanAxis],
         schema_channel: SubscanChannel,
-        coordinate_channels: List[ResultChannel],
-        child_result_sinks: Dict[ResultChannel, ArraySink],
-        aggregate_result_channels: Dict[ResultChannel, ResultChannel],
-        short_child_channel_names: Dict[str, ResultChannel],
-        analyses: List[DefaultAnalysis],
-        parent_analysis_result_channels: Dict[str, ResultChannel],
+        coordinate_channels: list[ResultChannel],
+        child_result_sinks: dict[ResultChannel, ArraySink],
+        aggregate_result_channels: dict[ResultChannel, ResultChannel],
+        short_child_channel_names: dict[str, ResultChannel],
+        analyses: list[DefaultAnalysis],
+        parent_analysis_result_channels: dict[str, ResultChannel],
     ):
         self._runner = runner
         self._fragment = fragment
@@ -52,10 +51,10 @@ class Subscan:
 
     def run(
         self,
-        axis_generators: List[Tuple[ParamHandle, ScanGenerator]],
+        axis_generators: list[tuple[ParamHandle, ScanGenerator]],
         options: ScanOptions = ScanOptions(),
         execute_default_analyses: bool = True
-    ) -> Tuple[Dict[ParamHandle, list], Dict[ResultChannel, list]]:
+    ) -> tuple[dict[ParamHandle, list], dict[ResultChannel, list]]:
         """Run the subscan with the given axis iteration specifications, and return the
         data point coordinates/result channel values.
 
@@ -84,10 +83,10 @@ class Subscan:
         return self._push_results(execute_default_analyses)
 
     def set_scan_spec(self,
-                      axis_generators: List[Tuple[ParamHandle, ScanGenerator]],
+                      axis_generators: list[tuple[ParamHandle, ScanGenerator]],
                       options: ScanOptions = ScanOptions()):
-        axes: List[ScanAxis] = []
-        generators: List[ScanGenerator] = []
+        axes: list[ScanAxis] = []
+        generators: list[ScanGenerator] = []
         self._coordinate_sinks = OrderedDict[ParamHandle, ArraySink]()
 
         for param_handle, generator in axis_generators:
@@ -156,8 +155,8 @@ class Subscan:
 
     def _handle_default_analyses(
         self,
-        axes: List[ScanAxis],
-        coordinate_sinks: Dict[ParamHandle, ArraySink],
+        axes: list[ScanAxis],
+        coordinate_sinks: dict[ParamHandle, ArraySink],
         always_run: bool,
     ):
         # Re-filter analyses based on actual scan axes to support slightly dodgy use
@@ -224,7 +223,7 @@ class Subscan:
 def setattr_subscan(owner: Fragment,
                     scan_name: str,
                     fragment: ExpFragment,
-                    axis_params: List[Tuple[Fragment, str]],
+                    axis_params: list[tuple[Fragment, str]],
                     save_results_by_default: bool = True,
                     expose_analysis_results: bool = True) -> Subscan:
     """Set up a scan for the given subfragment.
@@ -251,7 +250,7 @@ def setattr_subscan(owner: Fragment,
     """
 
     assert owner._building, "Can only create a subscan during build_fragment()"
-    assert not hasattr(owner, scan_name), "Field '{}' already exists".format(scan_name)
+    assert not hasattr(owner, scan_name), f"Field '{scan_name}' already exists"
 
     # Our own ScanRunner takes care of the fragment lifecycle.
     owner.detach_fragment(fragment)
@@ -265,7 +264,7 @@ def setattr_subscan(owner: Fragment,
 def setup_subscan(result_target: Fragment,
                   name_prefix: str,
                   scanned_fragment: ExpFragment,
-                  axis_params: List[Tuple[Fragment, str]],
+                  axis_params: list[tuple[Fragment, str]],
                   save_results_by_default: bool = True,
                   expose_analysis_results: bool = True) -> Subscan:
     # Override target parameter stores with newly created stores.
@@ -285,7 +284,7 @@ def setup_subscan(result_target: Fragment,
         #    the most common use case anyway).
         #  - Serialise the scan point coordinates into the scan spec.
         coordinate_channels.append(
-            result_target.setattr_result(name_prefix + "axis_{}".format(i),
+            result_target.setattr_result(name_prefix + f"axis_{i}",
                                          OpaqueChannel,
                                          save_by_default=save_results_by_default))
 
@@ -366,8 +365,8 @@ def setup_subscan(result_target: Fragment,
 class SubscanExpFragment(ExpFragment):
     def build_fragment(self,
                        scanned_fragment_parent: Fragment,
-                       scanned_fragment: Union[ExpFragment, str],
-                       axis_params: List[Tuple[Fragment, str]],
+                       scanned_fragment: ExpFragment | str,
+                       axis_params: list[tuple[Fragment, str]],
                        save_results_by_default: bool = True,
                        expose_analysis_results: bool = True) -> None:
         if isinstance(scanned_fragment, str):
@@ -382,7 +381,7 @@ class SubscanExpFragment(ExpFragment):
 
     def configure(
         self,
-        axis_generators: List[Tuple[ParamHandle, ScanGenerator]],
+        axis_generators: list[tuple[ParamHandle, ScanGenerator]],
         options: ScanOptions = ScanOptions()
     ) -> None:
         """Configure point generators for each scan axis, and scan options.

--- a/ndscan/experiment/utils.py
+++ b/ndscan/experiment/utils.py
@@ -1,6 +1,7 @@
 import json
 import numpy
-from typing import Any, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any
 
 
 def path_matches_spec(path: Iterable[str], spec: str) -> bool:
@@ -38,7 +39,7 @@ def dump_json(obj: Any) -> str:
     return json.dumps(obj, cls=NumpyToVanillaEncoder)
 
 
-def to_metadata_broadcast_type(obj: Any) -> Optional[Any]:
+def to_metadata_broadcast_type(obj: Any) -> Any | None:
     """Return ``obj`` in a form that can be directly broadcast/saved as a dataset, or
     (conservatively) return ``None`` if this is not possible.
 

--- a/ndscan/plots/annotation_items.py
+++ b/ndscan/plots/annotation_items.py
@@ -7,7 +7,6 @@ import logging
 import numpy
 from oitg import uncertainty_to_string
 import pyqtgraph
-from typing import Dict, Union, Optional, Tuple
 from .._qt import QtCore
 from ..utils import FIT_OBJECTS
 from .model import AnnotationDataSource
@@ -41,9 +40,9 @@ class ComputedCurveItem(AnnotationItem):
     def is_function_supported(function_name: str) -> bool:
         return function_name in FIT_OBJECTS
 
-    def __init__(self, function_name: str,
-                 data_sources: Dict[str, AnnotationDataSource], view_box, curve_item,
-                 x_limits: Tuple[Union[float, None], Union[float, None]]):
+    def __init__(self, function_name: str, data_sources: dict[str,
+                                                              AnnotationDataSource],
+                 view_box, curve_item, x_limits: tuple[float | None, float | None]):
         self._function = FIT_OBJECTS[function_name].fitting_function
         self._data_sources = data_sources
         self._view_box = view_box
@@ -145,8 +144,8 @@ class CurveItem(AnnotationItem):
 class VLineItem(AnnotationItem):
     """Vertical line marking a given x coordinate, with optional confidence interval."""
     def __init__(self, position_source: AnnotationDataSource,
-                 uncertainty_source: Optional[AnnotationDataSource], view_box,
-                 base_color, x_data_to_display_scale, x_unit_suffix):
+                 uncertainty_source: AnnotationDataSource | None, view_box, base_color,
+                 x_data_to_display_scale, x_unit_suffix):
         self._position_source = position_source
         self._uncertainty_source = uncertainty_source
         self._view_box = view_box

--- a/ndscan/plots/container_widgets.py
+++ b/ndscan/plots/container_widgets.py
@@ -18,7 +18,7 @@ def _make_dimensional_plot(model: ScanModel, get_alternate_names):
     if dim == 2:
         return Image2DPlotWidget(model, get_alternate_names)
     raise NotImplementedError(
-        "Plots for {}-dimensional data are not yet implemented".format(dim))
+        f"Plots for {dim}-dimensional data are not yet implemented")
 
 
 class RootWidget(QtWidgets.QWidget):
@@ -50,7 +50,7 @@ class RootWidget(QtWidgets.QWidget):
         self.plot_container = None
 
     def _set_window_title(self, title):
-        self.setWindowTitle("{} – ndscan".format(title))
+        self.setWindowTitle(f"{title} – ndscan")
 
     def _update_plot(self):
         if self.plot_container:

--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -4,7 +4,6 @@ from itertools import chain, repeat
 import logging
 import numpy as np
 import pyqtgraph
-from typing import Dict, Optional
 
 from .._qt import QtCore, QtGui
 from . import colormaps
@@ -55,10 +54,9 @@ def _coords_to_indices(coords, range_spec):
 class _ImagePlot:
     def __init__(self, image_item: pyqtgraph.ImageItem,
                  colorbar: pyqtgraph.ColorBarItem, active_channel_name: str,
-                 x_min: Optional[float], x_max: Optional[float],
-                 x_increment: Optional[float], y_min: Optional[float],
-                 y_max: Optional[float], y_increment: Optional[float],
-                 channels: Dict[str, dict]):
+                 x_min: float | None, x_max: float | None, x_increment: float | None,
+                 y_min: float | None, y_max: float | None, y_increment: float | None,
+                 channels: dict[str, dict]):
         self.image_item = image_item
         self.colorbar = colorbar
         self.channels = channels
@@ -255,7 +253,7 @@ class Image2DPlotWidget(AlternateMenuPanesWidget):
             y_datasets = extract_linked_datasets(self.y_schema["param"])
             for d, axis in chain(zip(x_datasets, repeat("x")),
                                  zip(y_datasets, repeat("y"))):
-                action = builder.append_action("Set '{}' from crosshair".format(d))
+                action = builder.append_action(f"Set '{d}' from crosshair")
                 action.triggered.connect(lambda *a, axis=axis, d=d:
                                          (self._set_dataset_from_crosshair(d, axis)))
             if len(x_datasets) == 1 and len(y_datasets) == 1:

--- a/ndscan/plots/model/__init__.py
+++ b/ndscan/plots/model/__init__.py
@@ -25,7 +25,8 @@ situations.)
 
 import logging
 import numpy
-from typing import Any, Callable, Dict, List, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 from ..._qt import QtCore
 from .online_analysis import OnlineNamedFitAnalysis
 
@@ -120,9 +121,9 @@ class OnlineAnalysisDataSource(AnnotationDataSource):
 
 
 class Annotation:
-    def __init__(self, kind: str, parameters: Dict[str, Any],
-                 coordinates: Dict[str, AnnotationDataSource],
-                 data: Dict[str, AnnotationDataSource]):
+    def __init__(self, kind: str, parameters: dict[str, Any],
+                 coordinates: dict[str, AnnotationDataSource],
+                 data: dict[str, AnnotationDataSource]):
         self.kind = kind
         self.parameters = parameters
         self.coordinates = coordinates
@@ -153,14 +154,14 @@ class Model(QtCore.QObject):
         self.context = context
         self.schema_revision = schema_revision
 
-    def get_channel_schemata(self) -> Dict[str, Any]:
+    def get_channel_schemata(self) -> dict[str, Any]:
         raise NotImplementedError
 
 
 class SinglePointModel(Model):
     point_changed = QtCore.pyqtSignal(object)
 
-    def get_point(self) -> Optional[Dict[str, Any]]:
+    def get_point(self) -> dict[str, Any] | None:
         raise NotImplementedError
 
 
@@ -169,7 +170,7 @@ class ScanModel(Model):
     points_appended = QtCore.pyqtSignal(dict)
     annotations_changed = QtCore.pyqtSignal(list)
 
-    def __init__(self, axes: List[Dict[str, Any]], schema_revision: int,
+    def __init__(self, axes: list[dict[str, Any]], schema_revision: int,
                  context: Context):
         super().__init__(schema_revision, context)
         self.axes = axes
@@ -177,13 +178,13 @@ class ScanModel(Model):
         self._annotation_schemata = []
         self._online_analyses = {}
 
-    def get_point_data(self) -> Dict[str, Any]:
+    def get_point_data(self) -> dict[str, Any]:
         raise NotImplementedError
 
-    def get_annotations(self) -> List[Annotation]:
+    def get_annotations(self) -> list[Annotation]:
         return self._annotations
 
-    def get_analysis_result_source(self, name: str) -> Optional[AnnotationDataSource]:
+    def get_analysis_result_source(self, name: str) -> AnnotationDataSource | None:
         raise NotImplementedError
 
     #
@@ -192,7 +193,7 @@ class ScanModel(Model):
     # design.
     #
 
-    def _set_annotation_schemata(self, schemata: List[Dict[str, Any]]):
+    def _set_annotation_schemata(self, schemata: list[dict[str, Any]]):
         """Replace annotations with ones created according to the given schemata.
 
         This will be called by concrete subclasses once/whenever they have received the
@@ -236,7 +237,7 @@ class ScanModel(Model):
                 Annotation(schema["kind"], schema.get("parameters", {}), *sources))
         self.annotations_changed.emit(self._annotations)
 
-    def _set_online_analyses(self, analysis_schemata: Dict[str, Dict[str,
+    def _set_online_analyses(self, analysis_schemata: dict[str, dict[str,
                                                                      Any]]) -> None:
         """Create and hook up online analyses from the given schema.
 

--- a/ndscan/plots/model/hdf5.py
+++ b/ndscan/plots/model/hdf5.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 import h5py
 from . import (Context, FixedDataSource, Model, Root, ScanModel, SinglePointModel)
 from .utils import call_later, emit_later
@@ -39,7 +39,7 @@ class HDF5Root(Root):
             self._model = HDF5ScanModel(axes, datasets, prefix, schema_revision,
                                         context)
 
-    def get_model(self) -> Optional[Model]:
+    def get_model(self) -> Model | None:
         return self._model
 
 
@@ -56,15 +56,15 @@ class HDF5SingleShotModel(SinglePointModel):
             self._point[key] = datasets[prefix + "point." + key][()]
         emit_later(self.point_changed, self._point)
 
-    def get_channel_schemata(self) -> Dict[str, Any]:
+    def get_channel_schemata(self) -> dict[str, Any]:
         return self._channel_schemata
 
-    def get_point(self) -> Optional[Dict[str, Any]]:
+    def get_point(self) -> dict[str, Any] | None:
         return self._point
 
 
 class HDF5ScanModel(ScanModel):
-    def __init__(self, axes: List[Dict[str, Any]], datasets: h5py.Group, prefix: str,
+    def __init__(self, axes: list[dict[str, Any]], datasets: h5py.Group, prefix: str,
                  schema_revision: int, context: Context):
         super().__init__(axes, schema_revision, context)
 
@@ -88,18 +88,18 @@ class HDF5ScanModel(ScanModel):
                     pass
 
         self._point_data = {}
-        for name in (["axis_{}".format(i) for i in range(len(self.axes))] +
+        for name in ([f"axis_{i}" for i in range(len(self.axes))] +
                      ["channel_" + c for c in self._channel_schemata.keys()]):
             self._point_data[name] = datasets[prefix + "points." + name][:]
         emit_later(self.points_appended, self._point_data)
 
-    def get_channel_schemata(self) -> Dict[str, Any]:
+    def get_channel_schemata(self) -> dict[str, Any]:
         return self._channel_schemata
 
-    def get_point_data(self) -> Dict[str, Any]:
+    def get_point_data(self) -> dict[str, Any]:
         return self._point_data
 
-    def get_analysis_result_source(self, name: str) -> Optional[FixedDataSource]:
+    def get_analysis_result_source(self, name: str) -> FixedDataSource | None:
         if name not in self._analysis_result_sources:
             return None
         return self._analysis_result_sources[name]

--- a/ndscan/plots/model/online_analysis.py
+++ b/ndscan/plots/model/online_analysis.py
@@ -1,7 +1,7 @@
 import asyncio
 from concurrent.futures import ProcessPoolExecutor
 from pyqtgraph import SignalProxy
-from typing import Any, Dict
+from typing import Any
 from ..._qt import QtCore
 from ...utils import FIT_OBJECTS
 
@@ -23,7 +23,7 @@ class OnlineNamedFitAnalysis(OnlineAnalysis):
     """
     _trigger_recompute_fit = QtCore.pyqtSignal()
 
-    def __init__(self, schema: Dict[str, Any], parent_model):
+    def __init__(self, schema: dict[str, Any], parent_model):
         super().__init__()
         self._schema = schema
         self._model = parent_model
@@ -61,7 +61,7 @@ class OnlineNamedFitAnalysis(OnlineAnalysis):
             error_key = key + "_error"
             if error_key in result:
                 raise ValueError(
-                    "Fit error key name collides with result: '{}'".format(error_key))
+                    f"Fit error key name collides with result: '{error_key}'")
             result[error_key] = value
         return result
 

--- a/ndscan/plots/model/select_point.py
+++ b/ndscan/plots/model/select_point.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 from ...utils import strip_prefix
 from . import ScanModel, SinglePointModel
 import numpy
@@ -17,18 +17,18 @@ class SelectPointFromScanModel(SinglePointModel):
         # TODO: Invalidate point data (reset index?) on channel schema change.
         self._source.channel_schemata_changed.connect(self.channel_schemata_changed)
 
-    def set_source_index(self, idx: Optional[int]) -> None:
+    def set_source_index(self, idx: int | None) -> None:
         if idx == self._source_index:
             return
         self._set_point(idx, silently_fail=False)
 
-    def get_channel_schemata(self) -> Dict[str, Any]:
+    def get_channel_schemata(self) -> dict[str, Any]:
         return self._source.get_channel_schemata()
 
-    def get_point(self) -> Optional[Dict[str, Any]]:
+    def get_point(self) -> dict[str, Any] | None:
         return self._point
 
-    def _set_point(self, idx: Optional[int], silently_fail: bool) -> None:
+    def _set_point(self, idx: int | None, silently_fail: bool) -> None:
         self._source_index = idx
         if idx is None:
             point = None

--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -7,7 +7,6 @@
 # in.
 
 import pyqtgraph
-from typing import List
 from .._qt import QtCore, QtGui, QtWidgets
 from .model import Context
 
@@ -135,7 +134,7 @@ class ContextMenuBuilder:
         self._entries = []
         self._target_menu = target_menu
 
-    def finish(self) -> List[QtGui.QAction]:
+    def finish(self) -> list[QtGui.QAction]:
         return self._entries
 
     def ensure_separator(self):
@@ -245,7 +244,7 @@ class SubplotMenuPanesWidget(AlternateMenuPanesWidget):
 
     def build_context_menu(self, pane_idx: int, builder: ContextMenuBuilder) -> None:
         for name in self.subscan_roots.keys():
-            action = builder.append_action("Open subscan '{}'".format(name))
+            action = builder.append_action(f"Open subscan '{name}'")
             action.triggered.connect(lambda *args, name=name: self.open_subplot(name))
         builder.ensure_separator()
         super().build_context_menu(pane_idx, builder)

--- a/ndscan/plots/utils.py
+++ b/ndscan/plots/utils.py
@@ -1,6 +1,6 @@
 import html
 import logging
-from typing import Any, Dict, List, Tuple
+from typing import Any
 from ..utils import eval_param_default
 
 logger = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ FIT_COLORS = [
 
 
 def extract_scalar_channels(
-        channels: Dict[str, Any]) -> Tuple[List[str], Dict[str, str]]:
+        channels: dict[str, Any]) -> tuple[list[str], dict[str, str]]:
     """Extract channels with scalar numerical values from the given channel metadata,
     also mapping error bar channels to their associated value channels.
 
@@ -26,8 +26,10 @@ def extract_scalar_channels(
         bars), the second a dictionary matching those channels to the associated error
         bars, if any.
     """
-    data_names = set(name for name, spec in channels.items()
-                     if spec["type"] in ["int", "float"])
+    data_names = {
+        name
+        for name, spec in channels.items() if spec["type"] in ["int", "float"]
+    }
 
     path_to_name = {channels[name]["path"]: name for name in data_names}
 
@@ -40,7 +42,7 @@ def extract_scalar_channels(
         if not err_path:
             continue
         if err_path not in path_to_name:
-            msg = "Error bar target '{}' does not exist".format(err_path)
+            msg = f"Error bar target '{err_path}' does not exist"
             if err_path in channels:
                 # Previously, this accepted the shortened name instead of the full path;
                 # suggest this to help users migrate.
@@ -81,8 +83,8 @@ def extract_scalar_channels(
     return data_names, error_bar_names
 
 
-def _get_share_name(name: str, keyword: str, channels: Dict[str, Any],
-                    path_to_name: Dict[str, str]):
+def _get_share_name(name: str, keyword: str, channels: dict[str, Any],
+                    path_to_name: dict[str, str]):
     """Extract the name of a channel from a display hint of another channel
 
     :param name: The name of the channel.
@@ -101,8 +103,8 @@ def _get_share_name(name: str, keyword: str, channels: Dict[str, Any],
     return path_to_name[path]
 
 
-def group_channels_into_axes(channels: Dict[str, Any],
-                             data_names: List[str]) -> List[List[str]]:
+def group_channels_into_axes(channels: dict[str, Any],
+                             data_names: list[str]) -> list[list[str]]:
     """Extract channels with scalar numerical values from the given channel metadata,
     also mapping error bar channels to their associated value channels.
 
@@ -171,8 +173,8 @@ def group_channels_into_axes(channels: Dict[str, Any],
     return [[name for (_, name) in axis] for axis in axes]
 
 
-def group_axes_into_panes(channels: Dict[str, Any],
-                          axes_names: List[List[str]]) -> List[List[List[str]]]:
+def group_axes_into_panes(channels: dict[str, Any],
+                          axes_names: list[list[str]]) -> list[list[list[str]]]:
     """Group axes returned by :func:`group_channels_into_axes` into plots by
         ``share_pane_with`` annotations in the channel's ``display_hints``.
 
@@ -189,7 +191,7 @@ def group_axes_into_panes(channels: Dict[str, Any],
     axes_share_idxs = []  # List of sets of indices of axes sharing one plot.
     for (idx, names) in enumerate(axes_names):
         # The axis indices with which the current axis is to share a plot.
-        share_idxs = set([idx])
+        share_idxs = {idx}
         for name in names:
             # Map all channel names specified to share a plot with the current axis
             # to their respective axis.
@@ -216,7 +218,7 @@ def group_axes_into_panes(channels: Dict[str, Any],
     return [[axes_names[axis] for axis in plot] for plot in plots]
 
 
-def extract_linked_datasets(param_schema: Dict[str, Any]) -> List[str]:
+def extract_linked_datasets(param_schema: dict[str, Any]) -> list[str]:
     """Extract datasets mentioned in the default value of the given parameter schema.
 
     :return: A list of dataset keys mentioned.
@@ -236,7 +238,7 @@ def extract_linked_datasets(param_schema: Dict[str, Any]) -> List[str]:
     return datasets
 
 
-def format_param_identity(schema: Dict[str, Any]) -> str:
+def format_param_identity(schema: dict[str, Any]) -> str:
     """Extract a string representation of the parameter identity from the given schema,
     for use in human-readable labels.
     """
@@ -247,7 +249,7 @@ def format_param_identity(schema: Dict[str, Any]) -> str:
     return shortened_fqn + "@" + path
 
 
-def setup_axis_item(axis_item, axes: List[Tuple[str, str, str, Dict[str, Any]]]):
+def setup_axis_item(axis_item, axes: list[tuple[str, str, str, dict[str, Any]]]):
     """Set up an axis item with the appropriate labels/scaling for the given axis
     metadata.
 
@@ -266,7 +268,7 @@ def setup_axis_item(axis_item, axes: List[Tuple[str, str, str, Dict[str, Any]]])
             if isinstance(color, str) and len(color) == 9 and color[0] == "#":
                 # KLUDGE: Reorder RGBA to ARGB.
                 color = "#" + color[7:] + color[1:7]
-            result += "<span style='color: \"{}\"'>".format(color)
+            result += f"<span style='color: \"{color}\"'>"
         unit = spec.get("unit", "")
         if unit:
             unit = "/ " + unit + " "

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -309,7 +309,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
         annotations = self.model.get_annotations()
         for a in annotations:
             if a.kind == "location":
-                if set(a.coordinates.keys()) == set(["axis_0"]):
+                if set(a.coordinates.keys()) == {"axis_0"}:
                     associated_series_idx = max(
                         channel_ref_to_series_idx(chan)
                         for chan in a.parameters.get("associated_channels", [None]))
@@ -325,7 +325,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
             if a.kind == "curve":
                 associated_series_idx = None
                 for series_idx, series in enumerate(self.series):
-                    match_coords = set(["axis_0", "channel_" + series.data_name])
+                    match_coords = {"axis_0", "channel_" + series.data_name}
                     if set(a.coordinates.keys()) == match_coords:
                         associated_series_idx = series_idx
                         break
@@ -361,7 +361,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
 
         if self.model.context.is_online_master():
             for d in extract_linked_datasets(x_schema["param"]):
-                action = builder.append_action("Set '{}' from crosshair".format(d))
+                action = builder.append_action(f"Set '{d}' from crosshair")
                 action.triggered.connect(
                     lambda *a, d=d: self._set_dataset_from_crosshair_x(pane_idx, d))
             builder.ensure_separator()

--- a/ndscan/results/arguments.py
+++ b/ndscan/results/arguments.py
@@ -2,12 +2,13 @@
 Functions for pretty-printing user argument data (scan parameters, overrides, …) for
 FragmentScanExperiments from ARTIQ results.
 """
-from typing import Any, Dict, Iterable
+from collections.abc import Iterable
+from typing import Any
 from sipyco import pyon
 from ..utils import PARAMS_ARG_KEY
 
 
-def extract_param_schema(arguments: Dict[str, Any]) -> Dict[str, Any]:
+def extract_param_schema(arguments: dict[str, Any]) -> dict[str, Any]:
     """Extract ndscan parameter data from the given ARTIQ arguments directory.
 
     :param arguments: The arguments for an ARTIQ experiment, as e.g. obtained using
@@ -21,14 +22,14 @@ def extract_param_schema(arguments: Dict[str, Any]) -> Dict[str, Any]:
     return pyon.decode(string)
 
 
-def format_numeric(value, spec: Dict[str, Any]) -> str:
+def format_numeric(value, spec: dict[str, Any]) -> str:
     unit = spec.get("unit", "")
     if not unit:
         return str(value)
     return f"{value / spec['scale']} {unit}"
 
 
-def dump_overrides(schema: Dict[str, Any]) -> Iterable[str]:
+def dump_overrides(schema: dict[str, Any]) -> Iterable[str]:
     """Format information about overrides as a human-readable string.
 
     :return: Generator yielding the output line-by-line.
@@ -42,7 +43,7 @@ def dump_overrides(schema: Dict[str, Any]) -> Iterable[str]:
             yield f"   ({fqn}@{path})"
 
 
-def format_scan_range(typ: str, rang: Dict[str, Any], param_spec: Dict[str,
+def format_scan_range(typ: str, rang: dict[str, Any], param_spec: dict[str,
                                                                        Any]) -> str:
     if typ == "linear":
         start = format_numeric(rang["start"], param_spec["spec"])
@@ -58,7 +59,7 @@ def format_scan_range(typ: str, rang: Dict[str, Any], param_spec: Dict[str,
     return f"<Unknown scan type '{typ}'.>"
 
 
-def dump_scan(schema: Dict[str, Any]) -> Iterable[str]:
+def dump_scan(schema: dict[str, Any]) -> Iterable[str]:
     """Format information about the configured scan (if any) as a human-readable string.
 
     :return: Generator yielding the output line-by-line.
@@ -86,7 +87,7 @@ def dump_scan(schema: Dict[str, Any]) -> Iterable[str]:
     yield f" - Randomise order globally: {scan['randomise_order_globally']}"
 
 
-def summarise(schema: Dict[str, Any]) -> str:
+def summarise(schema: dict[str, Any]) -> str:
     """Convenience method returning a combination of :meth:`dump_overrides` and
     :meth:`dump_scan` ready to be printed.
     """

--- a/ndscan/results/pyplot.py
+++ b/ndscan/results/pyplot.py
@@ -8,12 +8,12 @@ available.
 import json
 import matplotlib.pyplot as plt
 import numpy as np
-from typing import Any, Dict
+from typing import Any
 from ..plots.utils import extract_scalar_channels
 from .tools import find_ndscan_roots
 
 
-def make_default_1d_plot(datasets: Dict[str, Any],
+def make_default_1d_plot(datasets: dict[str, Any],
                          root: str,
                          figure,
                          *,
@@ -62,7 +62,7 @@ def make_default_1d_plot(datasets: Dict[str, Any],
     figure.tight_layout()
 
 
-def make_default_plot(datasets: Dict[str, Any],
+def make_default_plot(datasets: dict[str, Any],
                       root: str,
                       figure,
                       *,
@@ -81,7 +81,7 @@ def make_default_plot(datasets: Dict[str, Any],
                 num_axes))
 
 
-def auto_plot(datasets: Dict[str, Any], *, channel_filter=lambda name: True):
+def auto_plot(datasets: dict[str, Any], *, channel_filter=lambda name: True):
     """Display PyPlot figures for all the ndscan roots found among the passed datasets.
 
     :param channel_filter: Called with the name for each result channel; if False, the
@@ -93,4 +93,4 @@ def auto_plot(datasets: Dict[str, Any], *, channel_filter=lambda name: True):
         try:
             make_default_plot(datasets, root, fig, channel_filter=channel_filter)
         except NotImplementedError as e:
-            print("Skipping root '{}': {}".format(root, e))
+            print(f"Skipping root '{root}': {e}")

--- a/ndscan/results/tools.py
+++ b/ndscan/results/tools.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict, List
+from typing import Any
 from ..utils import SCHEMA_REVISION_KEY, strip_suffix
 
 
-def find_ndscan_roots(datasets: Dict[str, Any]) -> List[str]:
+def find_ndscan_roots(datasets: dict[str, Any]) -> list[str]:
     """Detect ndscan roots among the passed datasets, and returns a list of the name
     prefixes (e.g. ``ndscan.``).
     """
@@ -18,7 +18,7 @@ def find_ndscan_roots(datasets: Dict[str, Any]) -> List[str]:
     return results
 
 
-def get_source_id(datasets: Dict[str, Any], prefixes: List[str]):
+def get_source_id(datasets: dict[str, Any], prefixes: list[str]):
     # Take source_id from first prefix. This is pretty arbitrary, but for
     # experiment-generated files, they will all be the same anyway.
     if (prefixes[0] + "source_id") in datasets:

--- a/ndscan/show.py
+++ b/ndscan/show.py
@@ -73,7 +73,7 @@ def load_h5(args):
     except KeyError:
         QtWidgets.QMessageBox.critical(
             None, "Not an ARTIQ results file",
-            "No ARTIQ dataset records found in file: '{}'".format(args.path))
+            f"No ARTIQ dataset records found in file: '{args.path}'")
         sys.exit(1)
 
     prefix = fetch_explicit_prefix(args)
@@ -95,7 +95,7 @@ def load_h5(args):
         if not prefixes:
             QtWidgets.QMessageBox.critical(
                 None, "Not an ndscan file",
-                "No ndscan result datasets found in file: '{}'".format(args.path))
+                f"No ndscan result datasets found in file: '{args.path}'")
             sys.exit(1)
 
     try:
@@ -126,9 +126,8 @@ def main():
 
         roots = [HDF5Root(datasets, p, context) for p in prefixes]
     except Exception as e:
-        QtWidgets.QMessageBox.critical(
-            None, "Error parsing ndscan file",
-            "Error parsing datasets in '{}': {}".format(args.path, e))
+        QtWidgets.QMessageBox.critical(None, "Error parsing ndscan file",
+                                       f"Error parsing datasets in '{args.path}': {e}")
         sys.exit(2)
 
     if len(roots) == 1:

--- a/ndscan/to_txt.py
+++ b/ndscan/to_txt.py
@@ -51,7 +51,7 @@ def main():
     channel_schemata = json.loads(datasets[prefix + "channels"][()])
 
     for i, name in enumerate(axes_names):
-        dat = datasets[prefix + "points.axis_{}".format(i)][:]
+        dat = datasets[prefix + f"points.axis_{i}"][:]
         point_data[name] = dat
 
     for c, cval in channel_schemata.items():

--- a/ndscan/utils.py
+++ b/ndscan/utils.py
@@ -1,8 +1,9 @@
 """Odds and ends common to all of ndscan."""
 
+from collections.abc import Callable, Iterable
 from enum import Enum, unique
 import oitg.fitting
-from typing import Any, Callable, Dict, Iterable, Optional, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 
 #: Registry of well-known fit procedure names.
 FIT_OBJECTS = {
@@ -57,7 +58,7 @@ def strip_suffix(string: str, suffix: str) -> str:
 
 def shorten_to_unambiguous_suffixes(
         fqns: Iterable[str], get_last_n_parts: Callable[[str, int],
-                                                        str]) -> Dict[str, str]:
+                                                        str]) -> dict[str, str]:
     short_to_fqns = dict()
     shortened_fqns = dict()
 
@@ -99,7 +100,7 @@ class GetDataset(Protocol):
     If the ``key`` dataset does not exist, the callback should return the value given in
     the second parameter, ``default``, or if that is not specified, raise an exception.
     """
-    def __call__(self, key: str, default: Optional[T] = None) -> T:
+    def __call__(self, key: str, default: T | None = None) -> T:
         ...
 
 
@@ -114,6 +115,6 @@ def merge_no_duplicates(target: dict, source: dict, kind: str = "entries") -> No
     """Merges ``source`` into ``target``, raising a ``ValueError`` on duplicate keys."""
     for k, v in source.items():
         if k in target:
-            raise ValueError("Duplicate {} of key '{}'".format(kind, k))
+            raise ValueError(f"Duplicate {kind} of key '{k}'")
         target[k] = v
     return target


### PR DESCRIPTION
Prefer using the built-in types directly rather than the
original wrappers from the `typing` module.

Applied using pyupgrade --py310-plus.
