### PR TITLE
plots.xy_1d: Fix merge conflict breaking averaging menu entry

### DIFF
--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -371,7 +371,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
             action.setCheckable(True)
             action.setChecked(self.averaging_enabled)
             action.triggered.connect(
-                lambda *a, d=d: self.enable_averaging(not self.averaging_enabled))
+                lambda: self.enable_averaging(not self.averaging_enabled))
             builder.ensure_separator()
 
         super().build_context_menu(pane_idx, builder)


### PR DESCRIPTION
This was presumably introduced while resolving a merge conflict
in 2a7b13e835e19706062b65d2087226b3742e433c.
