### PR TITLE
131 plot unitsscale for shared axes channels broken

### DIFF
--- a/ndscan/plots/cursor.py
+++ b/ndscan/plots/cursor.py
@@ -1,6 +1,44 @@
 import numpy as np
 import pyqtgraph
 from .._qt import QtCore, QtWidgets
+from .utils import SERIES_COLORS
+
+
+class CrosshairLabel(pyqtgraph.TextItem):
+    def __init__(self,
+                 view_box: pyqtgraph.ViewBox,
+                 unit_suffix: float,
+                 data_to_display_scale: float,
+                 color: str = SERIES_COLORS[0],
+                 is_x: bool = False):
+        super().__init__(color=color)
+        # Don't take text item into account for auto-scaling; otherwise
+        # there will be positive feedback if the cursor is towards the
+        # bottom right of the screen.
+        self.setFlag(QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemHasNoContents)
+
+        self.view_box = view_box
+        self.unit_suffix = unit_suffix
+        self.data_to_display_scale = data_to_display_scale
+        self.is_x = is_x
+
+        self.last_value = None
+
+    def update(self, last_scene_pos: QtCore.QPointF):
+        data_coords = self.view_box.mapSceneToView(last_scene_pos)
+
+        x_range, y_range = self.view_box.state["viewRange"]
+        # We want to be able to resolve at least 1000 points in the displayed
+        # range.
+        r = np.array(x_range if self.is_x else y_range) * self.data_to_display_scale
+        smallest_digit = np.floor(np.log10(r[1] - r[0])) - 3
+        width = int(-smallest_digit) if smallest_digit < 0 else 0
+
+        coord = data_coords.x() if self.is_x else data_coords.y()
+        self.setText("{0:.{n}f}{1}".format(coord * self.data_to_display_scale,
+                                           self.unit_suffix,
+                                           n=width))
+        self.last_value = coord
 
 
 class LabeledCrosshairCursor(QtCore.QObject):
@@ -12,9 +50,8 @@ class LabeledCrosshairCursor(QtCore.QObject):
     trail of buffered redraws when there are a lot of points.
     """
     def __init__(self, cursor_target_widget: QtWidgets.QWidget,
-                 plot_item: pyqtgraph.PlotItem, x_unit_suffix: str,
-                 x_data_to_display_scale: float, y_unit_suffix: str,
-                 y_data_to_display_scale: float):
+                 plot_item: pyqtgraph.PlotItem,
+                 crosshair_entries: list[CrosshairLabel]):
         """
         :param cursor_target_widget: Widget to apply the cursor icon to.
         :param plot_item: Linked pyqtgraph plot.
@@ -22,11 +59,7 @@ class LabeledCrosshairCursor(QtCore.QObject):
         super().__init__()
 
         self.plot_item = plot_item
-
-        self.x_unit_suffix = x_unit_suffix
-        self.x_data_to_display_scale = x_data_to_display_scale
-        self.y_unit_suffix = y_unit_suffix
-        self.y_data_to_display_scale = y_data_to_display_scale
+        self.crosshair_entries = crosshair_entries
 
         self.plot_item.getViewBox().hoverEvent = self._on_viewbox_hover
         cursor_target_widget.setCursor(QtCore.Qt.CursorShape.CrossCursor)
@@ -34,17 +67,13 @@ class LabeledCrosshairCursor(QtCore.QObject):
         self.timer = QtCore.QTimer(self)
         self.timer.timeout.connect(self._update_text)
         self.timer.setSingleShot(True)
-        self.x_text = None
-        self.y_text = None
-        self.last_x = None
-        self.last_y = None
+        self._text_shown = False
 
     def _on_viewbox_hover(self, event):
         if event.isExit():
-            self.plot_item.removeItem(self.x_text)
-            self.x_text = None
-            self.plot_item.removeItem(self.y_text)
-            self.y_text = None
+            for item in self.crosshair_entries:
+                self.plot_item.removeItem(item)
+            self._text_shown = False
 
             self.timer.stop()
             return
@@ -54,51 +83,19 @@ class LabeledCrosshairCursor(QtCore.QObject):
 
     def _update_text(self):
         vb = self.plot_item.getViewBox()
-        data_coords = vb.mapSceneToView(self.last_hover_event.scenePos())
-
         # TODO: Draw text directly to graphics scene rather than going through
         # pyqtgraph for performance - don't need any of the fancy interaction
         # or layouting features that come with being a plot item.
 
-        def make_text():
-            text = pyqtgraph.TextItem()
-            # Don't take text item into account for auto-scaling; otherwise
-            # there will be positive feedback if the cursor is towards the
-            # bottom right of the screen.
-            text.setFlag(QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemHasNoContents)
-            self.plot_item.addItem(text)
-            return text
+        for (i, crosshair_entry) in enumerate(self.crosshair_entries):
+            if not self._text_shown:
+                self.plot_item.addItem(crosshair_entry)
 
-        if not self.x_text:
-            self.x_text = make_text()
+            last_scene_pos = self.last_hover_event.scenePos()
+            crosshair_entry.update(last_scene_pos)
 
-        if not self.y_text:
-            self.y_text = make_text()
+            text_pos = QtCore.QPointF(last_scene_pos)
+            text_pos.setY(last_scene_pos.y() + i * 10)
+            crosshair_entry.setPos(vb.mapSceneToView(text_pos))
 
-        x_range, y_range = vb.state["viewRange"]
-        x_range = np.array(x_range) * self.x_data_to_display_scale
-        y_range = np.array(y_range) * self.y_data_to_display_scale
-
-        def num_digits_after_point(r):
-            # We want to be able to resolve at least 1000 points in the displayed
-            # range.
-            smallest_digit = np.floor(np.log10(r[1] - r[0])) - 3
-            return int(-smallest_digit) if smallest_digit < 0 else 0
-
-        self.x_text.setText("{0:.{width}f}{1}".format(
-            data_coords.x() * self.x_data_to_display_scale,
-            self.x_unit_suffix,
-            width=num_digits_after_point(x_range)))
-        self.x_text.setPos(data_coords)
-
-        self.last_x = data_coords.x()
-
-        y_text_pos = QtCore.QPointF(self.last_hover_event.scenePos())
-        y_text_pos.setY(self.last_hover_event.scenePos().y() + 10)
-        self.y_text.setText("{0:.{width}f}{1}".format(
-            data_coords.y() * self.y_data_to_display_scale,
-            self.y_unit_suffix,
-            width=num_digits_after_point(y_range)))
-        self.y_text.setPos(vb.mapSceneToView(y_text_pos))
-
-        self.last_y = data_coords.y()
+        self._text_shown = True

--- a/ndscan/plots/cursor.py
+++ b/ndscan/plots/cursor.py
@@ -51,7 +51,7 @@ class LabeledCrosshairCursor(QtCore.QObject):
     """
     def __init__(self, cursor_target_widget: QtWidgets.QWidget,
                  plot_item: pyqtgraph.PlotItem,
-                 crosshair_entries: list[CrosshairLabel]):
+                 crosshair_items: list[CrosshairLabel]):
         """
         :param cursor_target_widget: Widget to apply the cursor icon to.
         :param plot_item: Linked pyqtgraph plot.
@@ -59,7 +59,7 @@ class LabeledCrosshairCursor(QtCore.QObject):
         super().__init__()
 
         self.plot_item = plot_item
-        self.crosshair_entries = crosshair_entries
+        self.crosshair_items = crosshair_items
 
         self.plot_item.getViewBox().hoverEvent = self._on_viewbox_hover
         cursor_target_widget.setCursor(QtCore.Qt.CursorShape.CrossCursor)
@@ -71,7 +71,7 @@ class LabeledCrosshairCursor(QtCore.QObject):
 
     def _on_viewbox_hover(self, event):
         if event.isExit():
-            for item in self.crosshair_entries:
+            for item in self.crosshair_items:
                 self.plot_item.removeItem(item)
             self._text_shown = False
 
@@ -87,15 +87,15 @@ class LabeledCrosshairCursor(QtCore.QObject):
         # pyqtgraph for performance - don't need any of the fancy interaction
         # or layouting features that come with being a plot item.
 
-        for (i, crosshair_entry) in enumerate(self.crosshair_entries):
+        for (i, crosshair_item) in enumerate(self.crosshair_items):
             if not self._text_shown:
-                self.plot_item.addItem(crosshair_entry)
+                self.plot_item.addItem(crosshair_item)
 
             last_scene_pos = self.last_hover_event.scenePos()
-            crosshair_entry.update(last_scene_pos)
+            crosshair_item.update(last_scene_pos)
 
             text_pos = QtCore.QPointF(last_scene_pos)
             text_pos.setY(last_scene_pos.y() + i * 10)
-            crosshair_entry.setPos(vb.mapSceneToView(text_pos))
+            crosshair_item.setPos(vb.mapSceneToView(text_pos))
 
         self._text_shown = True

--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -183,7 +183,7 @@ class ContextMenuPanesWidget(VerticalPanesWidget):
         # every time. This is slightly wasteful, but context menus should be created
         # seldomly enough for the slight increase in latency not to matter.
 
-        def get_context_menu(pane_idx=len(self.panes) - 1):
+        def get_context_menu(*args, pane_idx=len(self.panes) - 1):
             builder = ContextMenuBuilder(pane.getViewBox().menu)
             self.build_context_menu(pane_idx, builder)
             return builder.finish()

--- a/ndscan/plots/rolling_1d.py
+++ b/ndscan/plots/rolling_1d.py
@@ -90,12 +90,12 @@ class Rolling1DPlotWidget(AlternateMenuPanesWidget):
             self.error.emit(str(e))
             return
 
-        series_idx = 0
         axes = group_channels_into_axes(channels, data_names)
         plots_axes = group_axes_into_panes(channels, axes)
         for axes_names in plots_axes:
             pane = self.add_pane()
             pane.showGrid(x=True, y=True)
+            series_idx = 0
             for names in axes_names:
                 axis, view_box = pane.new_y_axis()
 

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -207,13 +207,13 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
             self.error.emit(str(e))
             return
 
-        series_idx = 0
         axes = group_channels_into_axes(channels, data_names)
         plots_axes = group_axes_into_panes(channels, axes)
 
         for axes_names in plots_axes:
             pane = self.add_pane()
             pane.showGrid(x=True, y=True)
+            series_idx = 0
             for names in axes_names:
                 axis, view_box = pane.new_y_axis()
                 view_box.scene().sigMouseClicked.connect(self._handle_scene_click)

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -371,7 +371,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
             action.setCheckable(True)
             action.setChecked(self.averaging_enabled)
             action.triggered.connect(
-                lambda: self.enable_averaging(not self.averaging_enabled))
+                lambda *a: self.enable_averaging(not self.averaging_enabled))
             builder.ensure_separator()
 
         super().build_context_menu(pane_idx, builder)


### PR DESCRIPTION
Fixes #131.
For every axis, each `(unit, scale)` combination gets a crosshair label entry with the color of the first data series of that kind.
When an axis is shared between data of different `(unit, scale)` combination, the first data series determines the scale of the axis and the axis label of all other data series gets an additional multiplier, such as `y × 100 / us`.
In the future, this could be improved by converting between different scales of different units if the multiplier is a factor of 10. The current solution works for any scale ratio, where up to 6 significant figures will be shown in the axis label.

Example plot:
![image](https://github.com/OxfordIonTrapGroup/ndscan/assets/49479443/cf7ca44b-50d2-4f97-afef-3c666bf0adf6)
