### PR TITLE
Fix plots clear

### DIFF
--- a/ndscan/plots/cursor.py
+++ b/ndscan/plots/cursor.py
@@ -31,7 +31,8 @@ class CrosshairLabel(pyqtgraph.TextItem):
     def set_value(self, value: float, limits: tuple[float, float]):
         # We want to be able to resolve at least 1000 points in the displayed
         # range.
-        smallest_digit = np.floor(np.log10(limits[1] - limits[0])) - 3
+        span = (limits[1] - limits[0]) * self.data_to_display_scale
+        smallest_digit = np.floor(np.log10(span)) - 3
         precision = int(-smallest_digit) if smallest_digit < 0 else 0
 
         self.setText("{0:.{n}f}{1}".format(value * self.data_to_display_scale,

--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -139,11 +139,10 @@ class VerticalPanesWidget(pyqtgraph.GraphicsLayoutWidget):
             # also part of it.
             pane.getAxis("bottom").setStyle(showValues=False)
 
-    def clear(self) -> None:
+    def clear_panes(self):
         for pane in self.panes:
             pane.reset_y_axes()
         self.panes.clear()
-        super().clear()
 
 
 class ContextMenuBuilder:

--- a/ndscan/plots/rolling_1d.py
+++ b/ndscan/plots/rolling_1d.py
@@ -78,10 +78,11 @@ class Rolling1DPlotWidget(AlternateMenuPanesWidget):
         self._history_length = 1024
 
     def _initialise_series(self):
+        self.clear_panes()
+        self.clear()
         for s in self.series:
             s.remove_items()
         self.series.clear()
-        self.clear()
 
         channels = self.model.get_channel_schemata()
         try:

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -192,6 +192,8 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
 
     def _initialise_series(self, channels):
         # Remove all currently shown items and any extra axes added.
+        self.clear_panes()
+        self.clear()
         for s in self.series:
             s.remove_items()
         self.series.clear()
@@ -199,7 +201,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
         self.unique_x_data.clear()
         self.found_duplicate_x_data = False
         self._clear_annotations()
-        self.clear()
+
         self.subscan_roots = create_subscan_roots(self.selected_point_model)
 
         try:


### PR DESCRIPTION
The way [pyqtgraph.widgets.GraphicsLayoutWidget](https://pyqtgraph.readthedocs.io/en/latest/_modules/pyqtgraph/widgets/GraphicsLayoutWidget.html#GraphicsLayoutWidget) forwards `clear()` from [pyqtgraph.GraphicsLayout](https://pyqtgraph.readthedocs.io/en/latest/api_reference/graphicsItems/graphicslayout.html) causes unexpected behaviour when attempting to overload that method. Aside from the method being ignored, even calling `super()` would not have worked as `GraphicsLayoutWidget` inherits from `GraphicsView`, which does not have a `clear()` method.

A more subtle problem seems to have been solved by changing the order of `clear()`, `removeItem()` calls with clearing the attributes from the respective objects.
Errors of the like
```QGraphicsScene::removeItem: item 0x17a7fb9bb40's scene (0x0) is different from this scene (0x17a7f77e340)```
that occurred when reinitialising the widget, e.g. when switching between subscan points, are now gone.