### PR TITLE
Fix source_id not shown with just one pane

### DIFF
--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -9,7 +9,7 @@ from .._qt import QtCore, QtGui
 from . import colormaps
 from .cursor import CrosshairAxisLabel, CrosshairLabel, LabeledCrosshairCursor
 from .model import ScanModel
-from .plot_widgets import AlternateMenuPanesWidget
+from .plot_widgets import AlternateMenuPanesWidget, add_source_id_label
 from .utils import (extract_linked_datasets, extract_scalar_channels,
                     format_param_identity, get_axis_scaling_info, setup_axis_item)
 
@@ -249,7 +249,7 @@ class Image2DPlotWidget(AlternateMenuPanesWidget):
     ready = QtCore.pyqtSignal()
 
     def __init__(self, model: ScanModel, get_alternate_plot_names):
-        super().__init__(model.context, get_alternate_plot_names)
+        super().__init__(get_alternate_plot_names)
 
         self.model = model
         self.model.channel_schemata_changed.connect(self._initialise_series)
@@ -309,6 +309,8 @@ class Image2DPlotWidget(AlternateMenuPanesWidget):
         self.crosshair = LabeledCrosshairCursor(
             self, self.plot_item,
             [x_crosshair_item, y_crosshair_item, self.plot.z_crosshair_item])
+
+        add_source_id_label(self.plot_item.getViewBox(), self.model.context)
 
         self.ready.emit()
 

--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -23,6 +23,7 @@ class MultiYAxisPlotItem(pyqtgraph.PlotItem):
         self._num_y_axes = 0
         self._additional_view_boxes = []
         self._additional_right_axes = []
+        self._source_id_label = None
 
     def show_border(self):
         self.getViewBox().setBorder(
@@ -82,13 +83,11 @@ class VerticalPanesWidget(pyqtgraph.GraphicsLayoutWidget):
     For the sake of clarity, the concept of one such subplot is consistently referred to
     as a "pane" throughout the code.
     """
-    def __init__(self, context: Context):
+    def __init__(self):
         super().__init__()
-        self._context = context
         self.layout: QtGui.QGraphicsGridLayout = self.ci.layout
         self.layout.setContentsMargins(3, 3, 3, 3)
         self.layout.setVerticalSpacing(3)
-        self.context = context
         self.panes = list[MultiYAxisPlotItem]()
 
     def add_pane(self) -> MultiYAxisPlotItem:
@@ -142,8 +141,6 @@ class VerticalPanesWidget(pyqtgraph.GraphicsLayoutWidget):
             # also part of it.
             pane.getAxis("bottom").setStyle(showValues=False)
 
-        add_source_id_label(self.panes[-1].getViewBox(), self._context)
-
     def clear_panes(self):
         for pane in self.panes:
             pane.reset_y_axes()
@@ -191,8 +188,8 @@ class ContextMenuBuilder:
 
 class ContextMenuPanesWidget(VerticalPanesWidget):
     """PlotWidget with support for dynamically populated context menus."""
-    def add_pane(self, *args, **kwargs) -> MultiYAxisPlotItem:
-        pane = super().add_pane(*args, *kwargs)
+    def add_pane(self) -> MultiYAxisPlotItem:
+        pane = super().add_pane()
 
         # The pyqtgraph getContextMenus() mechanism by default isn't very useful –
         # returned entries are appended to the menu every time the function is called.
@@ -236,8 +233,8 @@ class AlternateMenuPanesWidget(ContextMenuPanesWidget):
 
     alternate_plot_requested = QtCore.pyqtSignal(str)
 
-    def __init__(self, context: Context, get_alternate_plot_names):
-        super().__init__(context)
+    def __init__(self, get_alternate_plot_names):
+        super().__init__()
         self._get_alternate_plot_names = get_alternate_plot_names
 
     def build_context_menu(self, pane_idx: int, builder: ContextMenuBuilder) -> None:
@@ -255,7 +252,9 @@ class SubplotMenuPanesWidget(AlternateMenuPanesWidget):
     AlternateMenuPanesWidget functionality).
     """
     def __init__(self, context: Context, get_alternate_plot_names):
-        super().__init__(context, get_alternate_plot_names)
+        super().__init__(get_alternate_plot_names)
+        self._context = context
+
         #: Maps subscan names to model Root instances.
         self.subscan_roots = {}
 

--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -130,16 +130,15 @@ class VerticalPanesWidget(pyqtgraph.GraphicsLayoutWidget):
         for pane in self.panes:
             pane.getAxis("left").setWidth(max_axis_width)
 
-        # With more than one stacked plot with grids, having a complete border instead
-        # of drawing only the axes looks nicer.
-        for pane in self.panes:
+            # With more than one stacked plot with grids, having a complete border
+            # instead of drawing only the axes looks nicer.
             pane.show_border()
 
-        for pane in self.panes[:-1]:
-            pane.setXLink(self.panes[-1])
-            # We can't completely hide the bottom axis, as the vertical grid lines are
-            # also part of it.
-            pane.getAxis("bottom").setStyle(showValues=False)
+            if pane is not self.panes[-1]:
+                pane.setXLink(self.panes[-1])
+                # We can't completely hide the bottom axis, as the vertical grid lines
+                # are also part of it.
+                pane.getAxis("bottom").setStyle(showValues=False)
 
     def clear_panes(self):
         for pane in self.panes:

--- a/ndscan/plots/rolling_1d.py
+++ b/ndscan/plots/rolling_1d.py
@@ -4,7 +4,7 @@ import pyqtgraph
 from .._qt import QtCore, QtWidgets
 from .model import SinglePointModel
 from .plot_widgets import (AlternateMenuPanesWidget,
-                           build_channel_selection_context_menu)
+                           build_channel_selection_context_menu, add_source_id_label)
 from .utils import (extract_scalar_channels, get_default_hidden_channels,
                     group_channels_into_axes, group_axes_into_panes,
                     hide_series_from_groups, setup_axis_item, SERIES_COLORS)
@@ -70,7 +70,7 @@ class Rolling1DPlotWidget(AlternateMenuPanesWidget):
     ready = QtCore.pyqtSignal()
 
     def __init__(self, model: SinglePointModel, get_alternate_plot_names):
-        super().__init__(model.context, get_alternate_plot_names)
+        super().__init__(get_alternate_plot_names)
 
         self.model = model
         self.model.channel_schemata_changed.connect(self._initialise_series)
@@ -135,6 +135,8 @@ class Rolling1DPlotWidget(AlternateMenuPanesWidget):
 
         if len(self.panes) > 1:
             self.link_x_axes()
+
+        add_source_id_label(self.panes[-1].getViewBox(), self.model.context)
 
         self.ready.emit()
 

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -10,7 +10,8 @@ from .cursor import CrosshairAxisLabel, LabeledCrosshairCursor
 from .model import ScanModel
 from .model.select_point import SelectPointFromScanModel
 from .model.subscan import create_subscan_roots
-from .plot_widgets import SubplotMenuPanesWidget, build_channel_selection_context_menu
+from .plot_widgets import (SubplotMenuPanesWidget, build_channel_selection_context_menu,
+                           add_source_id_label)
 from .utils import (extract_linked_datasets, extract_scalar_channels,
                     get_default_hidden_channels, format_param_identity,
                     group_channels_into_axes, group_axes_into_panes,
@@ -269,6 +270,8 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
 
         if len(self.panes) > 1:
             self.link_x_axes()
+
+        add_source_id_label(self.panes[-1].getViewBox(), self.model.context)
 
         setup_axis_item(
             self.panes[-1].getAxis("bottom"),


### PR DESCRIPTION
Fix #361 by reverting to a previous state where the `source_id`s were added manually in the respective target widget.