### PR TITLE
363 xy 1d location annotation labels placed too high slightly clipped

### DIFF
--- a/ndscan/plots/annotation_items.py
+++ b/ndscan/plots/annotation_items.py
@@ -145,13 +145,14 @@ class VLineItem(AnnotationItem):
     """Vertical line marking a given x coordinate, with optional confidence interval."""
     def __init__(self, position_source: AnnotationDataSource,
                  uncertainty_source: AnnotationDataSource | None, view_box, base_color,
-                 x_data_to_display_scale, x_unit_suffix):
+                 x_data_to_display_scale, x_unit_suffix, show_label):
         self._position_source = position_source
         self._uncertainty_source = uncertainty_source
         self._view_box = view_box
         self._x_data_to_display_scale = x_data_to_display_scale
         self._x_unit_suffix = x_unit_suffix
         self._added_to_plot = False
+        self._show_label = show_label
 
         # Position label within initial view range.
         ymax_view = view_box.viewRange()[1][1]
@@ -222,7 +223,9 @@ class VLineItem(AnnotationItem):
         else:
             label = uncertainty_to_string(x * self._x_data_to_display_scale,
                                           delta_x * self._x_data_to_display_scale)
-        self._center_line.label.setFormat(label + self._x_unit_suffix)
+
+        if self._show_label:
+            self._center_line.label.setFormat(label + self._x_unit_suffix)
 
         self._left_line.setPos(x - delta_x)
         self._center_line.setPos(x)

--- a/ndscan/plots/annotation_items.py
+++ b/ndscan/plots/annotation_items.py
@@ -153,6 +153,11 @@ class VLineItem(AnnotationItem):
         self._x_unit_suffix = x_unit_suffix
         self._added_to_plot = False
 
+        # Position label within initial view range.
+        ymax_view = view_box.viewRange()[1][1]
+        ymax_scene = view_box.mapViewToScene(QtCore.QPointF(0, ymax_view)).y()
+        ypos_label = view_box.mapSceneToView(QtCore.QPointF(0, ymax_scene + 7)).y()
+
         self._left_line = pyqtgraph.InfiniteLine(movable=False,
                                                  angle=90,
                                                  pen={
@@ -163,7 +168,7 @@ class VLineItem(AnnotationItem):
                                                    angle=90,
                                                    label="",
                                                    labelOpts={
-                                                       "position": 0.97,
+                                                       "position": ypos_label,
                                                        "color": base_color,
                                                        "movable": True
                                                    },

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -352,6 +352,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
                             color,
                             self.x_data_to_display_scale,
                             self.x_unit_suffix,
+                            show_label=(series is associated_series[-1]),
                         )
                         self.annotation_items.append(line)
 


### PR DESCRIPTION
Fixes #363

Determines the location of the label based on the coordinates of the current scene.

Also now shows the label only on the bottom-most pane if there are multiple.