### PR TITLE
xy_1d: show computed_curve annotation even if no associated_channels given

### DIFF
--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -375,7 +375,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
             elif a.kind == "computed_curve":
                 function_name = a.parameters.get("function_name", None)
                 if ComputedCurveItem.is_function_supported(function_name):
-                    channel_refs = a.parameters.get("associated_channels", [])
+                    channel_refs = a.parameters.get("associated_channels", None)
                     associated_series = channel_refs_to_series(channel_refs)
                     for series in associated_series:
                         x_limits = [


### PR DESCRIPTION
With multiple panes and without specifying the `associated_channels` that will be obviously wrong.
Should we warn about this and hint at specifying the `associated_channels`?