### PR TITLE
plots.xy_1d: Show vertical line annotation in top pane instead of bottom

### DIFF
--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -352,7 +352,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
                             color,
                             self.x_data_to_display_scale,
                             self.x_unit_suffix,
-                            show_label=(series is associated_series[-1]),
+                            show_label=(series is associated_series[0]),
                         )
                         self.annotation_items.append(line)
 


### PR DESCRIPTION
Conforms better to my aesthetic sensibilities, and one has
the x-axis ticks for reference in the bottommost pane anyway.
