### PR TITLE
fragment.build: Allow fragments to have different sets of subfragments

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -287,14 +287,32 @@ class Fragment(HasEnvironment):
             :meth:`build_fragment` call.
         :return: The newly created fragment instance.
         """
-        assert self._building, ("Can only call setattr_fragment() "
+        assert not hasattr(self, name), f"Field '{name}' already exists"
+        frag = self.make_subfragment(name, fragment_class, *args, **kwargs)
+        setattr(self, name, frag)
+        return frag
+
+    def make_subfragment(self, name: str, fragment_class: type["Fragment"], *args,
+                         **kwargs) -> "Fragment":
+        """Build and return a fragment, adding it as a subfragment but
+        without setting it as an attribute
+        
+        Can only be called during :meth:`build_fragment`.
+
+        :param name: The fragment name; part of the fragment path. 
+        :param fragment_class: The type of the subfragment to instantiate.
+        :param args: Any extra arguments to forward to the subfragment
+            :meth:`build_fragment` call.
+        :param kwargs: Any extra keyword arguments to forward to the subfragment
+            :meth:`build_fragment` call.
+        :return: The newly created fragment instance.
+        """
+        assert self._building, ("Can only call setattr_fragment() or get_fragment()"
                                 "during build_fragment()")
         assert name.isidentifier(), "Subfragment name must be valid Python identifier"
-        assert not hasattr(self, name), f"Field '{name}' already exists"
 
         frag = fragment_class(self, self._fragment_path + [name], *args, **kwargs)
         self._subfragments.append(frag)
-        setattr(self, name, frag)
 
         return frag
 


### PR DESCRIPTION
## Problem description:

`bottom_level_frag` is a Fragment that implements some functionality with normal ARTIQ types. 

`mid_level_frag` is a Fragment which uses lists of `bottom_level_frag`s to do something. Its `build_fragment()` takes a parameter which allows it to contrust a list of `bottom_level_frag`s depending on the user's wants. 

`top_level_frag` is a Fragment which has at least two `mid_level_frag`s as subfragments, with different lists passed to their `build_fragment`. 

In this setup we end up with a problem because the two instances of `mid_level_frag` have subfrags with different names. If you call these subfragments as attributes of the class, the ARTIQ compiler complains because you now have two nominally same-typed objects that have different attributes. That's easy to avoid (and better) if you save your subfragments into a list and loop over them - now your class attributes are consistent. However `device_setup` and `device_cleanup` have references to class attributes baked in by name. 

## MWE

```
from artiq.experiment import kernel
from ndscan.experiment import Fragment, ExpFragment


class TopLevelFrag(ExpFragment):
    def build_fragment(self):
        self.setattr_device("core")

        self.setattr_fragment("subfrag_1", MidLevelFrag, ["hello", "world"])
        self.setattr_fragment(
            "subfrag_2", MidLevelFrag, ["different", "strings", "here"]
        )

    @kernel
    def run_once(self) -> None:
        print("Hello")


class MidLevelFrag(Fragment):
    def build_fragment(self, list_of_strings):
        self.setattr_device("core")

        self.subfrags = []
        for my_string in list_of_strings:
            self.subfrags.append(
                self.setattr_fragment(
                    "subfrag_" + my_string, BottomLevelFrag, bottom_frag_arg=my_string
                )
            )

    @kernel
    def do_many_somethings(self):
        for frag in self.subfrags:
            frag.do_something()


class BottomLevelFrag(Fragment):
    def build_fragment(self, bottom_frag_arg=None):
        self.setattr_device("core")

        self.arg = bottom_frag_arg

    @kernel
    def do_something(self):
        print(self.arg)

```

Running TopLevelFrag gives (please ignore the extra stuff from our unit tests):

```
<snip>

self = <artiq.coredevice.core._DiagnosticEngine object at 0x7fb3d67c5ff0>
diagnostic = <pythonparser.diagnostic.Diagnostic object at 0x7fb3d667d540>

    def process(self, diagnostic):
        """
        The default implementation of :meth:`process` renders non-fatal
        diagnostics to ``sys.stderr``, and raises fatal ones as a :class:`Error`.
        """
        diagnostic.notes += self._appended_notes
        self.render_diagnostic(diagnostic)
        if diagnostic.level == "fatal" or \
                (self.all_errors_are_fatal and diagnostic.level == "error"):
>           raise Error(diagnostic)
E           pythonparser.diagnostic.Error: <synthesized>:1:1-1:72: error: host object does not have an attribute 'subfrag_hello'; did you mean 'subfrag_here'?
E           `<test_ndscan_polymorphism_demo.MidLevelFrag object at 0x7fb3d67c59f0>`
E           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           /home/charles/ghorg/aion-physics/code/artiq/forks/ndscan/ndscan/experiment/fragment.py:133:1: note: expanded from here
E           def device_setup(self) -> None:
E           ^                              
E           <string>:2:5-2:23: note: attribute accessed here
E               self.subfrag_hello.device_setup()
E               ^^^^^^^^^^^^^^^^^^

../.cache/pypoetry/virtualenvs/icl-experiments-NH0wbGjr-py3.10/lib/python3.10/site-packages/pythonparser/diagnostic.py:165: Error

The above exception was the direct cause of the following exception:

<snip>

>           raise CompileError(error.diagnostic) from error
E           artiq.coredevice.core.CompileError: 
E           [1;37m<synthesized>:1:1-1:72: [31merror:[37m host object does not have an attribute 'subfrag_hello'; did you mean 'subfrag_here'?[0m
E           `<test_ndscan_polymorphism_demo.MidLevelFrag object at 0x7fb3d67c59f0>`
E           [1;32m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
E           [1;37m/home/charles/ghorg/aion-physics/code/artiq/forks/ndscan/ndscan/experiment/fragment.py:133:1: [30mnote:[37m expanded from here[0m
E           def device_setup(self) -> None:
E           [1;32m^                              [0m
E           [1;37m<string>:2:5-2:23: [30mnote:[37m attribute accessed here[0m
E               self.subfrag_hello.device_setup()
E           [1;32m    ^^^^^^^^^^^^^^^^^^               [0m

../.cache/pypoetry/virtualenvs/icl-experiments-NH0wbGjr-py3.10/lib/python3.10/site-packages/artiq/coredevice/core.py:127: CompileError
----------------------------- Captured stderr call -----------------------------
[1;37m<synthesized>:1:1-1:72: [31merror:[37m host object does not have an attribute 'subfrag_hello'; did you mean 'subfrag_here'?[0m
`<test_ndscan_polymorphism_demo.MidLevelFrag object at 0x7fb3d67c59f0>`
[1;32m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
[1;37m/home/charles/ghorg/aion-physics/code/artiq/forks/ndscan/ndscan/experiment/fragment.py:133:1: [30mnote:[37m expanded from here[0m
def device_setup(self) -> None:
[1;32m^                              [0m
[1;37m<string>:2:5-2:23: [30mnote:[37m attribute accessed here[0m
    self.subfrag_hello.device_setup()
[1;32m    ^^^^^^^^^^^^^^^^^^               [0m
```

## Fix

This PR avoids the problem by replacing the kernel generation code. Instead of referring to subfragments by name, we sort them into lists of subfragments of the same type and then call them by index. So e.g. for `device_cleanup` instead of 

```
try:
    self.subfrag_here.device_cleanup()
except Exception:
    logger.error("Cleanup failed for 'subfrag_2/subfrag_here'.")
try:
    self.subfrag_strings.device_cleanup()
except Exception:
    logger.error("Cleanup failed for 'subfrag_2/subfrag_strings'.")
try:
    self.subfrag_different.device_cleanup()
except Exception:
    logger.error("Cleanup failed for 'subfrag_2/subfrag_different'.")
```

we get

```
try:
    self.__subfrags_BottomLevelFrag[2].device_cleanup()
except Exception:
    logger.error("Cleanup failed for 'subfrag_2/subfrag_here'.")
try:
    self.__subfrags_BottomLevelFrag[1].device_cleanup()
except Exception:
    logger.error("Cleanup failed for 'subfrag_2/subfrag_strings'.")
try:
    self.__subfrags_BottomLevelFrag[0].device_cleanup()
except Exception:
    logger.error("Cleanup failed for 'subfrag_2/subfrag_different'.")
```

...avoiding the use of names which might change. 

Also, adds a method `make_subfragment` which is identical to `setattr_fragment` except that it doesn't add the fragment as an attribute (similar in concept to ARTIQ's `get_device` vs. `setattr_device`). 