### PR TITLE
utils.shorten_to_unambiguous_suffixes: Fix bug by simplified rewrite, document

### DIFF
--- a/ndscan/utils.py
+++ b/ndscan/utils.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable, Iterable
 from enum import Enum, unique
+from itertools import pairwise
 import oitg.fitting
 from typing import Any, Protocol, TypeVar
 
@@ -56,41 +57,76 @@ def strip_suffix(string: str, suffix: str) -> str:
     return string
 
 
-def shorten_to_unambiguous_suffixes(
-        fqns: Iterable[str], get_last_n_parts: Callable[[str, int],
-                                                        str]) -> dict[str, str]:
-    short_to_fqns = dict()
-    shortened_fqns = dict()
-
-    for current in fqns:
-        if current in shortened_fqns:
-            continue
-
-        n = 1
-        while True:
-            candidate = get_last_n_parts(current, n)
-            if candidate not in short_to_fqns:
-                short_to_fqns[candidate] = {current}
-                shortened_fqns[current] = candidate
-                break
-
-            # We have a conflict, disambiguate.
-            existing_fqns = short_to_fqns[candidate]
-            for old in existing_fqns:
-                if shortened_fqns[old] == candidate:
-                    # This hasn't previously been moved to a higher n, so
-                    # do it now.
-                    new = get_last_n_parts(old, n + 1)
-                    shortened_fqns[old] = new
-                    short_to_fqns[new] = {old}
-                    break  # Exits inner for loop.
-            existing_fqns.add(current)
-            n += 1
-
-    return shortened_fqns
-
-
 T = TypeVar("T")
+
+
+# As of Python 3.12, there does not seem to be a straightforward way to specify T as
+# being ordered; as this is going to be ``str`` anyway in virtually all cases, just
+# live with the inaccuracy until we actually integrate a type checker.
+def shorten_to_unambiguous_suffixes(
+        fqns: Iterable[T], get_last_n_parts: Callable[[T, int], T]) -> dict[T, T]:
+    """Shorten a list of names (typically fully qualified names or paths, "FQNs") by
+    removing common prefixes where possible to leave only the suffixes necessary to
+    keep the names unambiguous.
+
+    The strings are not truncated at arbitrary locations, but only at separators
+    dividing the full names into parts (e.g. ``/``, ``.``). In this implementation, this
+    is achieved via the ``get_last_n_parts()`` parameter, which is flexible but a bit
+    inefficient; if the strings are long, the implementation should be specialised for
+    e.g. the common case of parts being delimited by a single separator character.
+
+    :param fqns: The collection of names to shorten (typically ``str``s, but could be
+        an arbitrary type that is ordered and supports a notion of reversal via
+        ``[::-1]``). The elements must be unique, but are not assumed to be sorted in
+        any particular order.
+    :param get_last_n_parts: A callable (function/lambda/…) such that
+        ``get_last_n_parts(fqn, n)`` returns the ``n`` last parts of FQN. What
+        constitutes a part can be adapted to the application, but it must be consistent
+        with the obvious notion of "last" such that strings with the same
+        ``get_last_n_parts`` result actually share a common string suffix (of
+        whatever arbitrary length). The case where ``n`` exceeds the number of available
+        parts should be handled by (simply returning the full
+        element in that case). Example: ``lambda fqn, n: "/".join(fqn.split("/")[-n:])``
+        is a simple implementation to split strings at forward slashes.
+    :return: A dictionary mapping each long FQN to its shortened equivalent.
+    :raises: :class:`ValueError` on duplicate fqns.
+    """
+
+    # First, sort the given names by looking at each string in reverse order. This way,
+    # potentially colliding suffixes will always be adjacent to each other.
+    sorted_fqns = sorted(fqns, key=lambda fqn: fqn[::-1])
+    if not sorted_fqns:
+        return {}
+
+    # For every pair of names, obtain the minimum number of parts by just increasing it
+    # until the names differ. This simple implementation is slightly painful to write to
+    # the performance-minded programmer (needlessly quadratic time complexity), but wins
+    # out on simplicity while keeping the generic get_last_n_parts() interface.
+    def min_n_for_pair(fqn_a, fqn_b):
+        if fqn_a == fqn_b:
+            raise ValueError(f"Duplicate fqn '{fqn_a}'")
+        n = 1
+        while get_last_n_parts(fqn_a, n) == get_last_n_parts(fqn_b, n):
+            n += 1
+        return n
+
+    # Now, build the result map by iterating through sorted_fqns and taking enough parts
+    # to disambiguate each entry from its two neighbours. The first and last only have
+    # one neighbour, being reflected in the initial value for min_n_with_prev and the
+    # final store() call for the last element.
+    result = dict[T, T]()
+
+    def store(fqn, n):
+        result[fqn] = get_last_n_parts(fqn, n)
+
+    min_n_with_prev = 1
+    for current_fqn, next_fqn in pairwise(sorted_fqns):
+        min_n_with_next = min_n_for_pair(current_fqn, next_fqn)
+        store(current_fqn, max(min_n_with_prev, min_n_with_next))
+        min_n_with_prev = min_n_with_next
+    store(sorted_fqns[-1], min_n_with_prev)
+
+    return result
 
 
 class GetDataset(Protocol):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from itertools import permutations
 from ndscan.utils import strip_prefix, strip_suffix, shorten_to_unambiguous_suffixes
 
 
@@ -14,11 +15,16 @@ class StripTest(unittest.TestCase):
 
 class ShortenTest(unittest.TestCase):
     def test_shorten(self):
+        def shorten_at_slash(fqns):
+            return shorten_to_unambiguous_suffixes(
+                fqns, lambda fqn, n: "/".join(fqn.split("/")[-n:]))
+
         def test(expected):
-            self.assertEqual(
-                shorten_to_unambiguous_suffixes(
-                    expected.keys(), lambda fqn, n: "/".join(fqn.split("/")[-n:])),
-                expected)
+            # Test all orderings.
+            for keys in permutations(expected.keys()):
+                self.assertEqual(shorten_at_slash(keys), expected)
+
+        test({})
 
         test({"foo": "foo"})
         test({"": "", "foo/bar": "foo/bar", "foo/baz": "baz", "baz/bar": "baz/bar"})
@@ -27,3 +33,9 @@ class ShortenTest(unittest.TestCase):
         test({"a1/b/c": "a1/b/c", "a2/b/c": "a2/b/c"})
         test({"a1/b/c/d": "a1/b/c/d", "a2/b/c/d": "a2/b/c/d"})
         test({"a1/b/c/d/e": "a1/b/c/d/e", "a2/b/c/d/e": "a2/b/c/d/e"})
+
+        test({"bar": "bar", "foo/bar": "foo/bar"})
+
+        # Test repeated fqns.
+        with self.assertRaises(ValueError):
+            shorten_at_slash(["foo/bar", "foo/bar"])


### PR DESCRIPTION
The added `["bar", "foo/bar"]` test case failed depending on the order
in the old implementation.

This new, much more straightforward implementation might lead to subtly
different disambiguations in some cases, but if such cases in fact do
exist, this seems like a worthwhile trade-off to make, since we never
actually document the details of the shortening algorithm in the user
visible parts, or state that it is unchanging. If the changes do turn
out to be obnoxious for some established analysis pipeline, we could
salvage the old implementation quite easily by skipping the "promotion"
check if `old == current`, but rewriting this was quicker than
convincing myself that this fix actually would address all the corner
cases.
