### PR TITLE
Fix BoolParam rebinding (#383)

### DIFF
--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -435,7 +435,7 @@ class StringParam(ParamBase):
         return StringParamStore(identity, value)
 
 
-class BoolParam:
+class BoolParam(ParamBase):
     HandleType = BoolParamHandle
     StoreType = BoolParamStore
     CompilerType = bool
@@ -445,10 +445,10 @@ class BoolParam:
                  description: str,
                  default: str | bool,
                  is_scannable: bool = True):
-        self.fqn = fqn
-        self.description = description
-        self.default = default
-        self.is_scannable = is_scannable
+        super().__init__(fqn=fqn,
+                         description=description,
+                         default=default,
+                         is_scannable=is_scannable)
 
     def describe(self) -> dict[str, Any]:
         return {

--- a/test/test_experiment_parameters.py
+++ b/test/test_experiment_parameters.py
@@ -1,86 +1,106 @@
-import unittest
+from mock_environment import HasEnvironmentCase
+from ndscan.experiment.fragment import Fragment
 from ndscan.experiment.parameters import FloatParam, IntParam, BoolParam
 
 
-class FloatParamCase(unittest.TestCase):
-    def test_describe(self):
-        param = FloatParam("foo", "bar", 1.0, min=0.0, max=2.0, unit="baz", scale=1.0)
-        self.assertEqual(
-            param.describe(), {
-                "fqn": "foo",
-                "description": "bar",
-                "default": "1.0",
-                "spec": {
-                    "min": 0.0,
-                    "max": 2.0,
-                    "unit": "baz",
-                    "scale": 1.0,
-                    "step": 0.1,
-                    "is_scannable": True,
-                },
-                "type": "float"
-            })
+# "Container class" to hide base class from unittest auto-discovery.
+class GenericBase:
+    class Cases(HasEnvironmentCase):
+        def test_describe(self):
+            param = self.CLASS("foo", **self.EXAMPLE_KWARGS)
+            self.assertEqual(param.describe(),
+                             self.EXPECTED_DESCRIPTION | {"fqn": "foo"})
 
-    def test_evaluate_default(self):
-        def mock_get_dataset(key: str, default=None):
-            return {"baz": 42.0}[key]
+        def test_evaluate_default(self):
+            def mock_get_dataset(key: str, default=None):
+                return {"baz": self.DEFAULT_1}[key]
 
-        param = FloatParam("foo", "bar", 0.0)
-        self.assertEqual(param.eval_default(mock_get_dataset), 0.0)
+            param = self.CLASS("foo", "bar", self.DEFAULT_0)
+            self.assertEqual(param.eval_default(mock_get_dataset), self.DEFAULT_0)
 
-        param = FloatParam("foo", "bar", "dataset('baz', 0.0)")
-        self.assertEqual(param.eval_default(mock_get_dataset), 42.0)
+            param = self.CLASS("foo", "bar", f"dataset('baz', {self.DEFAULT_0})")
+            self.assertEqual(param.eval_default(mock_get_dataset), self.DEFAULT_1)
 
+        def test_rebind(self):
+            class Foo(Fragment):
+                def build_fragment(inner_self) -> None:
+                    inner_self.setattr_param("bar", self.CLASS, **self.EXAMPLE_KWARGS)
+                    inner_self.setattr_param_rebind("baz", inner_self, "bar")
 
-class IntParamCase(unittest.TestCase):
-    def test_describe(self):
-        param = IntParam("foo", "bar", 0, min=-1, max=1, unit="baz", scale=1)
-        self.assertEqual(
-            param.describe(), {
-                "fqn": "foo",
-                "description": "bar",
-                "default": "0",
-                "spec": {
-                    "min": -1,
-                    "max": 1,
-                    "unit": "baz",
-                    "scale": 1,
-                    "is_scannable": True,
-                },
-                "type": "int"
-            })
-
-    def test_evaluate_default(self):
-        def mock_get_dataset(key: str, default=None):
-            return {"baz": 42}[key]
-
-        param = IntParam("foo", "bar", 0)
-        self.assertEqual(param.eval_default(mock_get_dataset), 0)
-
-        param = IntParam("foo", "bar", "dataset('baz', 0)")
-        self.assertEqual(param.eval_default(mock_get_dataset), 42)
+            foo = self.create(Foo, [])
+            schemata = {}
+            foo._collect_params({}, schemata)
+            fqn = next(iter(schemata.keys()))
+            self.assertTrue(fqn.endswith("Foo.baz"))
+            self.assertEqual(schemata[fqn], self.EXPECTED_DESCRIPTION | {"fqn": fqn})
 
 
-class BoolParamCase(unittest.TestCase):
-    def test_describe(self):
-        param = BoolParam("foo", "bar", True)
-        self.assertEqual(
-            param.describe(), {
-                "fqn": "foo",
-                "description": "bar",
-                "type": "bool",
-                "default": "True",
-                "spec": {
-                    "is_scannable": True
-                }
-            })
+class FloatParamCase(GenericBase.Cases):
+    CLASS = FloatParam
+    DEFAULT_0 = 1.0
+    DEFAULT_1 = 42.0
+    EXAMPLE_KWARGS = {
+        "description": "bar",
+        "default": 1.0,
+        "min": 0.0,
+        "max": 2.0,
+        "unit": "baz",
+        "scale": 1.0
+    }
+    EXPECTED_DESCRIPTION = {
+        "description": "bar",
+        "default": "1.0",
+        "type": "float",
+        "spec": {
+            "min": 0.0,
+            "max": 2.0,
+            "unit": "baz",
+            "scale": 1.0,
+            "step": 0.1,
+            "is_scannable": True
+        }
+    }
 
-    def test_evaluate_default(self):
-        def mock_get_dataset(key: str, default=None):
-            return {"baz": True}[key]
 
-        param = BoolParam("foo", "bar", True)
-        self.assertEqual(param.eval_default(mock_get_dataset), True)
+class IntParamCase(GenericBase.Cases):
+    CLASS = IntParam
+    DEFAULT_0 = 1
+    DEFAULT_1 = 42
+    EXAMPLE_KWARGS = {
+        "description": "bar",
+        "default": 0,
+        "min": -1,
+        "max": 1,
+        "unit": "baz",
+        "scale": 1
+    }
+    EXPECTED_DESCRIPTION = {
+        "description": "bar",
+        "default": "0",
+        "type": "int",
+        "spec": {
+            "min": -1,
+            "max": 1,
+            "unit": "baz",
+            "scale": 1,
+            "is_scannable": True,
+        },
+    }
 
-        param = BoolParam("foo", "bar", "dataset('baz', False)")
-        self.assertEqual(param.eval_default(mock_get_dataset), True)
+
+class BoolParamCase(GenericBase.Cases):
+    CLASS = BoolParam
+    DEFAULT_0 = False
+    DEFAULT_1 = True
+    EXAMPLE_KWARGS = {
+        "description": "bar",
+        "default": True,
+    }
+    EXPECTED_DESCRIPTION = {
+        "description": "bar",
+        "default": "True",
+        "type": "bool",
+        "spec": {
+            "is_scannable": True,
+        },
+    }

--- a/test/test_experiment_parameters.py
+++ b/test/test_experiment_parameters.py
@@ -23,13 +23,13 @@ class FloatParamCase(unittest.TestCase):
 
     def test_evaluate_default(self):
         def mock_get_dataset(key: str, default=None):
-            return {"baz": 42.}[key]
+            return {"baz": 42.0}[key]
 
-        param = FloatParam("foo", "bar", 0.)
-        self.assertEqual(param.eval_default(mock_get_dataset), 0.)
+        param = FloatParam("foo", "bar", 0.0)
+        self.assertEqual(param.eval_default(mock_get_dataset), 0.0)
 
-        param = FloatParam("foo", "bar", "dataset('baz', 0.)")
-        self.assertEqual(param.eval_default(mock_get_dataset), 42.)
+        param = FloatParam("foo", "bar", "dataset('baz', 0.0)")
+        self.assertEqual(param.eval_default(mock_get_dataset), 42.0)
 
 
 class IntParamCase(unittest.TestCase):


### PR DESCRIPTION
- test_experiment_parameters: Avoid 0. incomplete floating-point syntax [nfc]
- experiment.parameters: Fix BoolParam rebinding/setattr_param_like
- test_experiment_parameters: Refactor to share code, add rebinding test
