### PR TITLE
experiment.scan_runner: Fix on-kernel scan compilation after 577b3fb

### DIFF
--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -9,8 +9,7 @@ will likely be used by end users via
 import logging
 import numpy as np
 from artiq.coredevice.exceptions import RTIOUnderflow
-from artiq.language import (HasEnvironment, host_only, kernel, kernel_from_string, rpc,
-                            TList, TTuple)
+from artiq.language import HasEnvironment, host_only, kernel, kernel_from_string, rpc
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from itertools import islice
@@ -263,10 +262,9 @@ class KernelScanRunner(ScanRunner):
         # run_chunk() correctly.
         self._get_param_values_chunk.__func__.__annotations__ = {
             "return":
-            TTuple([
-                TList(type_string_to_param(a.param_schema["type"]).CompilerType)
-                for a in axes
-            ])
+            tuple.__class_getitem__(
+                tuple(list[type_string_to_param(a.param_schema["type"]).CompilerType]
+                      for a in axes))
         }
 
         # Build kernel function that calls _get_param_values_chunk() and iterates over


### PR DESCRIPTION
The issue is that ARTIQ does not convert built-in types to
artiq.compiler types when used as arguments to compiler types,
which was the case here for TTuple/TList.

We desperately need kernel tests as part of the test suite; this
would have been caught by the most straightforward scan execution
test.
