### PR TITLE
387 clean reset of applet state when scan is overwritten

### DIFF
--- a/ndscan/plots/model/subscriber.py
+++ b/ndscan/plots/model/subscriber.py
@@ -37,14 +37,14 @@ class SubscriberRoot(Root):
         if schema_revision is None:
             return
 
-        fqn = d("fragment_fqn")
-        if not self._title_set or self._context.get_title() != fqn:
+        if not self._title_set:
+            fqn = d("fragment_fqn")
             if fqn:
                 self._context.set_title(fqn)
                 self._title_set = True
 
-        source_id = d("source_id")
-        if not self._source_id_set or self._context.get_source_id() != source_id:
+        if not self._source_id_set:
+            source_id = d("source_id")
             if source_id:
                 self._context.set_source_id(source_id)
                 self._source_id_set = True
@@ -194,21 +194,10 @@ class SubscriberScanModel(ScanModel):
         for name, source in self._analysis_result_sources.items():
             source.set(values.get(self._prefix + "analysis_result." + name))
 
-        point_data_changed = False
         for name in ([f"axis_{i}" for i in range(len(self.axes))] +
                      ["channel_" + c for c in self._channel_schemata.keys()]):
-            point_values = values.get(self._prefix + "points." + name, [])
-            if not point_data_changed:
-                # Check if points were appended or rewritten.
-                if name in self._point_data:
-                    imax = min(len(point_values), len(self._point_data[name]))
-                    if point_values[:imax] != self._point_data[name][:imax]:
-                        point_data_changed = True
-            self._point_data[name] = point_values
-        if point_data_changed:
-            self.points_rewritten.emit(self._point_data)
-        else:
-            self.points_appended.emit(self._point_data)
+            self._point_data[name] = values.get(self._prefix + "points." + name, [])
+        self.points_appended.emit(self._point_data)
 
     def get_annotations(self) -> list[Annotation]:
         return self._annotations

--- a/ndscan/plots/model/subscriber.py
+++ b/ndscan/plots/model/subscriber.py
@@ -37,6 +37,14 @@ class SubscriberRoot(Root):
         if schema_revision is None:
             return
 
+        source_id = d("source_id")
+        if self._context.get_source_id() != source_id:
+            # If the source_id changed, clear the applet.
+            self._model = None
+            self._title_set = False
+            self._source_id_set = False
+            self._axes_initialised = False
+
         if not self._title_set:
             fqn = d("fragment_fqn")
             if fqn:
@@ -44,7 +52,6 @@ class SubscriberRoot(Root):
                 self._title_set = True
 
         if not self._source_id_set:
-            source_id = d("source_id")
             if source_id:
                 self._context.set_source_id(source_id)
                 self._source_id_set = True

--- a/ndscan/plots/rolling_1d.py
+++ b/ndscan/plots/rolling_1d.py
@@ -136,7 +136,7 @@ class Rolling1DPlotWidget(AlternateMenuPanesWidget):
 
         if len(self.panes) > 1:
             self.link_x_axes()
-            add_source_id_label(self.panes[-1].getViewBox(), self.model.context)
+        add_source_id_label(self.panes[-1].getViewBox(), self.model.context)
 
         self.ready.emit()
 

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -171,6 +171,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
         self.model.channel_schemata_changed.connect(self._initialise_series)
         self.model.points_appended.connect(self._update_points)
         self.model.annotations_changed.connect(self._update_annotations)
+        # FIXME: Just re-set values instead of throwing away everything.
         self.model.points_rewritten.connect(self._rewrite)
 
         self.selected_point_model = SelectPointFromScanModel(self.model)


### PR DESCRIPTION
When the `source_id` changes, just reset the applet state.