### PR TITLE
Transitive rebinding

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -579,21 +579,17 @@ class Fragment(HasEnvironment):
         # rebindings until a free parameter is reached.
         toplevel_source = source.owner._find_param_source(source.name)
 
-        # We don't support "transitive" binding for parameters that are already bound.
-        assert source.name in source.owner._free_params, \
-            "Source parameter is not a free parameter; already bound/overridden?"
-
         own_type = type(self._free_params[param_name])
-        source_type = type(source.owner._free_params[source.name])
+        source_type = type(toplevel_source.owner._free_params[toplevel_source.name])
         assert own_type == source_type, (
             f"Cannot bind {own_type.__name__} '{param_name}' " +
             f"to source of type {source_type.__name__}")
 
         del self._free_params[param_name]
 
-        self._rebound_own_params[param_name] = source
+        self._rebound_own_params[param_name] = toplevel_source
 
-        source.owner._rebound_subfragment_params.setdefault(source.name, []).extend(
+        toplevel_source.owner._rebound_subfragment_params.setdefault(toplevel_source.name, []).extend(
             self._get_all_handles_for_param(param_name))
 
         return param

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -541,17 +541,13 @@ class Fragment(HasEnvironment):
         """
         if param_name in self._free_params:
             return getattr(self, param_name)
+        elif param_name in self._rebound_own_params:
+            p = self._rebound_own_params[param_name]
+            return p.owner._find_param_source(p.name)
         else:
-            try:
-                rebound_param = self._rebound_own_params[param_name]
-
             # Do not support binding to parameters that are overridden
-            except KeyError:
-                raise KeyError(
-                    f"Parameter '{param_name}' is not free or rebound. Was it overridden?"
-                )
-
-            return rebound_param.owner._find_param_source(rebound_param.name)
+            raise KeyError(
+                f"Parameter '{param_name}' is not free or rebound. Was it overridden?")
 
     def bind_param(self, param_name: str, source: ParamHandle) -> Any:
         """Override the fragment parameter with the given name such that its value

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -61,8 +61,13 @@ class Fragment(HasEnvironment):
         self._free_params = OrderedDict()
 
         #: Maps own attribute name to the ParamHandles of the rebound parameters in
-        #: their original subfragment.
-        self._rebound_subfragment_params = dict()
+        #: their original subfragment, for parameters of this Fragment which are
+        #: rebind targets.
+        self._rebound_subfragment_params :dict[str, list[ParamHandle]] = dict()
+
+        #: Maps own attribute name to the Fragment and attribute name that this parameter was
+        #: rebound to, for parameters of this Fragment which have been rebound.
+        self._rebound_own_params : dict[str, tuple[Fragment, str]] = dict()
 
         #: List of (param, store) tuples of parameters set to their defaults after
         #: init_params().
@@ -547,6 +552,8 @@ class Fragment(HasEnvironment):
             f"to source of type {source_type.__name__}")
 
         del self._free_params[param_name]
+
+        self._rebound_own_params[param_name] = (source.owner, source.name)
 
         source.owner._rebound_subfragment_params.setdefault(source.name, []).extend(
             self._get_all_handles_for_param(param_name))

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -536,18 +536,18 @@ class Fragment(HasEnvironment):
         :param param_name: The name of the parameter to find the target for.
         :return: The ParamHandle for the parameter in the fragment that
             has this parameter as a free parameter.
-        :raises KeyError: If the parameter is not free or rebound (e.g. it was
+        :raises AssertError: If the parameter is not free or rebound (e.g. it was
             overridden).
         """
         if param_name in self._free_params:
             return getattr(self, param_name)
-        elif param_name in self._rebound_own_params:
-            p = self._rebound_own_params[param_name]
-            return p.owner._find_param_source(p.name)
         else:
             # Do not support binding to parameters that are overridden
-            raise KeyError(
+            assert param_name in self._rebound_own_params, (
                 f"Parameter '{param_name}' is not free or rebound. Was it overridden?")
+
+            p = self._rebound_own_params[param_name]
+            return p.owner._find_param_source(p.name)
 
     def bind_param(self, param_name: str, source: ParamHandle) -> Any:
         """Override the fragment parameter with the given name such that its value

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -589,8 +589,9 @@ class Fragment(HasEnvironment):
 
         self._rebound_own_params[param_name] = toplevel_source
 
-        toplevel_source.owner._rebound_subfragment_params.setdefault(toplevel_source.name, []).extend(
-            self._get_all_handles_for_param(param_name))
+        toplevel_source.owner._rebound_subfragment_params.setdefault(
+            toplevel_source.name,
+            []).extend(self._get_all_handles_for_param(param_name))
 
         return param
 

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -586,11 +586,19 @@ class Fragment(HasEnvironment):
 
         del self._free_params[param_name]
 
+        # Record where this ParamHandle was rebound to
         self._rebound_own_params[param_name] = source
 
+        # Add all ParamHandles currently pointing at this parameter in this
+        # Fragment to the top level Fragment instead
         toplevel_source.owner._rebound_subfragment_params.setdefault(
             toplevel_source.name,
             []).extend(self._get_all_handles_for_param(param_name))
+
+        # If this parameter was previously a target of rebinds, remove it from
+        # this Fragment's list
+        if param_name in self._rebound_subfragment_params:
+            del self._rebound_subfragment_params[param_name]
 
         return param
 

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -560,6 +560,9 @@ class Fragment(HasEnvironment):
         ``Fluoresce``, binding its intensity and detuning parameters to values and
         defaults appropriate for those particular tasks.
 
+        Transitive binding is supported: if the source parameter is itself bound to
+        another parameter, this parameter will be bound to the ultimate source.
+
         See :meth:`override_param`, which sets the parameter to a fixed value/store.
 
         :param param_name: The name of the parameter to be bound (i.e.

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -63,11 +63,11 @@ class Fragment(HasEnvironment):
         #: Maps own attribute name to the ParamHandles of the rebound parameters in
         #: their original subfragment, for parameters of this Fragment which are
         #: rebind targets.
-        self._rebound_subfragment_params :dict[str, list[ParamHandle]] = dict()
+        self._rebound_subfragment_params: dict[str, list[ParamHandle]] = dict()
 
         #: Maps own attribute name to the Fragment and attribute name that this parameter was
         #: rebound to, for parameters of this Fragment which have been rebound.
-        self._rebound_own_params : dict[str, tuple[Fragment, str]] = dict()
+        self._rebound_own_params: dict[str, tuple[Fragment, str]] = dict()
 
         #: List of (param, store) tuples of parameters set to their defaults after
         #: init_params().
@@ -519,6 +519,41 @@ class Fragment(HasEnvironment):
             handle.set_store(store)
         return param, store
 
+    def _find_param_owner(self, param_name: str) -> tuple["Fragment", str]:
+        """Find the owner of the parameter with the given name.
+
+        Follows the chain of rebindings to find the Fragment which currently has
+        this parameter as a free parameter.
+
+        This is used to support "transitive" binding of parameters, where a
+        parameter is bound to another parameter that is itself bound to another
+        parameter, etc. 
+        
+        Note that binding to parameters that are *overridden*
+        instead of rebound is not supported. 
+
+        :param param_name: The name of the parameter to find the target for.
+        :return: A tuple ``(final_source, final_param_name)`` of the final
+            source fragment and parameter name that the given parameter is bound
+            to.
+        :raises KeyError: If the parameter is not free or rebound (e.g. it was
+            overridden).
+        """
+        if param_name in self._free_params:
+            return self, param_name
+        else:
+            try:
+                rebind_target_frag, rebind_param_name = self._rebound_own_params[
+                    param_name]
+
+            # Do not support binding to parameters that are overridden
+            except KeyError:
+                raise KeyError(
+                    f"Parameter '{param_name}' is not free or rebound. Was it overridden?"
+                )
+
+            return rebind_target_frag._find_param_owner(rebind_param_name)
+
     def bind_param(self, param_name: str, source: ParamHandle) -> Any:
         """Override the fragment parameter with the given name such that its value
         follows that of another parameter.
@@ -535,11 +570,15 @@ class Fragment(HasEnvironment):
         :param param_name: The name of the parameter to be bound (i.e.
             ``self.<param_name>``). Must be a free parameter of this fragment (not
             already bound or overridden).
-        :param source: The parameter to bind to. Must be a free parameter of its
-            respective owner.
+        :param source: The parameter to bind to. Must not be overridden in the
+            source fragment (but can be bound).
         """
         param = self._free_params.get(param_name, None)
         assert param is not None, f"Not a free parameter: '{param_name}'"
+
+        # To support "transitive" binding of parameters, follow the chaining of
+        # rebindings until a free parameter is reached.
+        owner, owner_param_name = source.owner._find_param_owner(source.name)
 
         # We don't support "transitive" binding for parameters that are already bound.
         assert source.name in source.owner._free_params, \

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -569,7 +569,7 @@ class Fragment(HasEnvironment):
             ``self.<param_name>``). Must be a free parameter of this fragment (not
             already bound or overridden).
         :param source: The parameter to bind to. Must not be overridden in the
-            source fragment (but can be bound).
+            owner fragment (but can be bound).
         """
         param = self._free_params.get(param_name, None)
         assert param is not None, f"Not a free parameter: '{param_name}'"

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -586,7 +586,7 @@ class Fragment(HasEnvironment):
 
         del self._free_params[param_name]
 
-        self._rebound_own_params[param_name] = toplevel_source
+        self._rebound_own_params[param_name] = source
 
         toplevel_source.owner._rebound_subfragment_params.setdefault(
             toplevel_source.name,

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -61,8 +61,7 @@ class Fragment(HasEnvironment):
         self._free_params = OrderedDict()
 
         #: Maps own attribute name to the ParamHandles of the rebound parameters in
-        #: their original subfragment (currently always only one, as there is only a
-        #: rebinding API that targets single paths).
+        #: their original subfragment.
         self._rebound_subfragment_params = dict()
 
         #: List of (param, store) tuples of parameters set to their defaults after

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ndscan"
-version = "v0.4.0"
+version = "v0.4.1"
 description = "Composable experiment fragments and multi-dimensional scans for ARTIQ"
 authors = ["David Nadlinger <code@klickverbot.at>"]
 license = "LGPLv3+"

--- a/test/test_experiment_fragment.py
+++ b/test/test_experiment_fragment.py
@@ -76,6 +76,25 @@ class TestRebinding(HasEnvironmentCase):
         self.assertEqual(result[mrf.first.result], 3)
         self.assertEqual(result[mrf.second.result], 3)
 
+    def test_transitive_rebind(self):
+        class TransitiveReboundAddOneFragment(ExpFragment):
+            def build_fragment(self):
+                self.setattr_fragment("first", AddOneFragment)
+                self.setattr_fragment("second", AddOneFragment)
+                self.setattr_param_like("value", self.first)
+                self.first.bind_param("value", self.value)
+                self.second.bind_param("value", self.first.value)
+
+            def run_once(self):
+                self.first.run_once()
+                self.second.run_once()
+
+        trf = self.create(TransitiveReboundAddOneFragment, [])
+        trf.override_param("value", 2)
+        result = run_fragment_once(trf)
+        self.assertEqual(result[trf.first.result], 3)
+        self.assertEqual(result[trf.second.result], 4)
+
     def test_invalid_bind(self):
         class InvalidBindFragment(ExpFragment):
             def build_fragment(self):

--- a/test/test_experiment_fragment.py
+++ b/test/test_experiment_fragment.py
@@ -81,7 +81,9 @@ class TestRebinding(HasEnvironmentCase):
             def build_fragment(self):
                 self.setattr_fragment("first", AddOneFragment)
                 self.setattr_fragment("second", AddOneFragment)
+
                 self.setattr_param_like("value", self.first)
+
                 self.first.bind_param("value", self.value)
                 self.second.bind_param("value", self.first.value)
 
@@ -93,7 +95,7 @@ class TestRebinding(HasEnvironmentCase):
         trf.override_param("value", 2)
         result = run_fragment_once(trf)
         self.assertEqual(result[trf.first.result], 3)
-        self.assertEqual(result[trf.second.result], 4)
+        self.assertEqual(result[trf.second.result], 3)
 
     def test_invalid_bind(self):
         class InvalidBindFragment(ExpFragment):

--- a/test/test_experiment_fragment.py
+++ b/test/test_experiment_fragment.py
@@ -97,6 +97,22 @@ class TestRebinding(HasEnvironmentCase):
         self.assertEqual(result[trf.first.result], 3)
         self.assertEqual(result[trf.second.result], 3)
 
+    def test_transitive_rebind_with_override_fails(self):
+        class OverriddenTransitiveReboundAddOneFragment(ExpFragment):
+            def build_fragment(self):
+                self.setattr_fragment("first", AddOneFragment)
+                self.setattr_fragment("second", AddOneFragment)
+
+                self.first.override_param("value", 2)
+                self.second.bind_param("value", self.first.value)
+
+            def run_once(self):
+                self.first.run_once()
+                self.second.run_once()
+
+        with self.assertRaises(AssertionError):
+            self.create(OverriddenTransitiveReboundAddOneFragment, [])
+
     def test_invalid_bind(self):
         class InvalidBindFragment(ExpFragment):
             def build_fragment(self):


### PR DESCRIPTION
Adds support for transitive rebinding of parameters.

If fragment A has two children, B and C, support already existed for overriding `C.my_param` to depend on `B.my_param` then `B.my_param` to depend on `A.my_param`. 

This PR lets you do it the other way around, giving the same final result but reversing the call order so you can first bind `B.my_param` to `A.my_param`, then `C.my_param` to `B.my_param`. 

We found this need pop up when wanting to bind parameters between subfragments at the same hierarchical level. 