### PR TITLE
fragment: Remove out-of-date rebinding implementation comment [nfc]

### DIFF
--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -61,8 +61,7 @@ class Fragment(HasEnvironment):
         self._free_params = OrderedDict()
 
         #: Maps own attribute name to the ParamHandles of the rebound parameters in
-        #: their original subfragment (currently always only one, as there is only a
-        #: rebinding API that targets single paths).
+        #: their original subfragment.
         self._rebound_subfragment_params = dict()
 
         #: List of (param, store) tuples of parameters set to their defaults after


### PR DESCRIPTION
I believe this comment is out of date, since in e.g. test_multi_rebind
_rebound_subfragment_params does indeed end up with two ParamHandles for the "value" parameter.
