### PR TITLE
Add NumericChannel.get_last method

### DIFF
--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -291,6 +291,7 @@ class NumericChannel(ResultChannel):
     def push(self, raw_value) -> None:
         """
         """
+        self._value_pushed = True
         self._last_value = raw_value
         self._push(raw_value)
 

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -2,7 +2,7 @@
 Result handling building blocks.
 """
 
-from artiq.language import HasEnvironment, portable, rpc
+from artiq.language import HasEnvironment, kernel, portable, rpc
 import artiq.language.units
 from typing import Any
 from .utils import dump_json
@@ -280,8 +280,13 @@ class NumericChannel(ResultChannel):
         self._value_pushed: bool = False
         self._last_value = self._coerce_to_type(0)
 
-    @portable
+    @kernel
     def get_last(self):
+        """ Returns the last value pushed to this result channel.
+
+        This method is a workaround for limitations of ARTIQ python, which make it
+        impractical to extract values from the sinks without going through RPCs.
+        """
         if not self._value_pushed:
             raise RuntimeError("No value pushed to channel")
 

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -2,7 +2,7 @@
 Result handling building blocks.
 """
 
-from artiq.language import HasEnvironment, rpc
+from artiq.language import HasEnvironment, portable, rpc
 import artiq.language.units
 from typing import Any
 from .utils import dump_json
@@ -276,6 +276,29 @@ class NumericChannel(ResultChannel):
                                    "the scale manually".format(unit))
         self.scale = scale
         self.unit = unit
+
+        self._value_pushed: bool = False
+        self._last_value = self._coerce_to_type(0)
+
+    @portable
+    def get_last(self):
+        if not self._value_pushed:
+            raise RuntimeError("No value pushed to channel")
+
+        return self._last_value
+
+    @portable
+    def push(self, raw_value) -> None:
+        """
+        """
+        self._last_value = raw_value
+        self._push(raw_value)
+
+    @rpc(flags={"async"})
+    def _push(self, raw_value) -> None:
+        """
+        """
+        super().push(raw_value)
 
     def describe(self) -> dict[str, Any]:
         """"""


### PR DESCRIPTION
This PR introduces a new `NumericChannel.get_last` method (mirroring the interface provided by sinks).

Prior to this PR there was no means of getting the results from a fragment within a kernel (the closest option was to use `channel._sink.get_last` and hope that's supported by the sink type). This feature is useful, for example, in `ExpFragment`s which aggregate multiple other `ExpFragment`s into a single experiment and want to have some form of feedforward based on result values.

Closes https://github.com/OxfordIonTrapGroup/ndscan/issues/415