### PR TITLE
Let AggregateExpFragments take callables as well as exp fragments

### DIFF
--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -202,7 +202,13 @@ class AddOneAggregate(AggregateExpFragment):
     def build_fragment(self) -> None:
         self.setattr_fragment("a", AddOneFragment)
         self.setattr_fragment("b", AddOneFragment)
-        return super().build_fragment([self.a, self.b])
+
+        self.setattr_result("sum", FloatChannel)
+
+        def push_sum():
+            self.sum.push(self.a.value.get() + 1 + self.b.value.get() + 1)
+
+        return super().build_fragment([self.a, self.b, push_sum])
 
 
 class TrivialKernelAggregate(AggregateExpFragment):

--- a/test/test_experiment_entrypoint.py
+++ b/test/test_experiment_entrypoint.py
@@ -32,6 +32,7 @@ class TestAggregateExpFragment(HasEnvironmentCase):
         self.assertEqual(parent.b.num_prepare_calls, 1)
         self.assertEqual(result[parent.a.result], 1.0)
         self.assertEqual(result[parent.b.result], 1.0)
+        self.assertEqual(result[parent.sum], 2.0)
 
     def test_kernel(self):
         parent = self.create(TrivialKernelAggregate, [])


### PR DESCRIPTION
Closes https://github.com/OxfordIonTrapGroup/ndscan/issues/416

See #416 for discussion

I haven't added a kernel test for this but would be happy to do so if requested. Not sure the best way of doing this - perhaps making all of `AddOneFragment`'s methods protable and then having `AddOneAggregate` take a build-time boolean flag to determine whether it runs on the kernel or host? Suggestions welcome!