### PR TITLE
plots: Fix for PyQt5

### DIFF
--- a/ndscan/_qt.py
+++ b/ndscan/_qt.py
@@ -13,6 +13,6 @@ __all__ = ["QtCore", "QtGui", "QtWidgets"]
 # This appears to be the only non-backwards-compatible change we came across during the
 # migration; if more are discovered in the future, appropriate shims should be inserted
 # here.
-for name in ("QAction", "QActionGroup"):
+for name in ("QAction", "QActionGroup", "QShortcut"):
     if not hasattr(QtGui, name):
         setattr(QtGui, name, getattr(QtWidgets, name))


### PR DESCRIPTION
This fixes a060b1afca4ec7187822e39600a5344966c7c2ed for PyQt5,
where QShortcut is still in QtWidgets.
