### PR TITLE
plots: Fix HDF5 loading error when default annotations present

### DIFF
--- a/ndscan/plots/model/hdf5.py
+++ b/ndscan/plots/model/hdf5.py
@@ -63,9 +63,6 @@ class HDF5ScanModel(ScanModel):
 
         self._channel_schemata = json.loads(datasets[prefix + "channels"][()])
 
-        self._set_online_analyses(json.loads(datasets[prefix + "online_analyses"][()]))
-        self._set_annotation_schemata(json.loads(datasets[prefix + "annotations"][()]))
-
         self._analysis_result_sources = {}
         ark = prefix + "analysis_results"
         if ark in datasets:
@@ -81,6 +78,9 @@ class HDF5ScanModel(ScanModel):
         for name in ([f"axis_{i}" for i in range(len(self.axes))] +
                      ["channel_" + c for c in self._channel_schemata.keys()]):
             self._point_data[name] = datasets[prefix + "points." + name][:]
+
+        self._set_online_analyses(json.loads(datasets[prefix + "online_analyses"][()]))
+        self._set_annotation_schemata(json.loads(datasets[prefix + "annotations"][()]))
 
     def get_channel_schemata(self) -> dict[str, Any]:
         return self._channel_schemata


### PR DESCRIPTION
This was a regression introduced in
b2a292f1eb39a50cab064ad06002e524059d81f2 which removed swathes of
call_later() – without it, the annotations were processed before the
points were set.
