### PR TITLE
Add option to repeat each point (before changing params) in a scan

### DIFF
--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -74,24 +74,24 @@ class ScanOptions:
 
         #
 
-        self.repeat_each_point_container = QtWidgets.QWidget()
-        repeat_each_point_layout = QtWidgets.QHBoxLayout()
-        repeat_each_point_layout.setContentsMargins(5, 5, 5, 5)
-        self.repeat_each_point_container.setLayout(repeat_each_point_layout)
+        self.num_repeats_per_point_container = QtWidgets.QWidget()
+        num_repeats_per_point_layout = QtWidgets.QHBoxLayout()
+        num_repeats_per_point_layout.setContentsMargins(5, 5, 5, 5)
+        self.num_repeats_per_point_container.setLayout(num_repeats_per_point_layout)
 
-        repeat_each_point_label = QtWidgets.QLabel(
+        num_repeats_per_point_label = QtWidgets.QLabel(
             "Number of consecutive repeats of each point: ")
-        repeat_each_point_layout.addWidget(repeat_each_point_label)
-        repeat_each_point_layout.setStretchFactor(repeat_each_point_label, 0)
+        num_repeats_per_point_layout.addWidget(num_repeats_per_point_label)
+        num_repeats_per_point_layout.setStretchFactor(num_repeats_per_point_label, 0)
 
-        self.repeat_each_point_box = QtWidgets.QSpinBox()
-        self.repeat_each_point_box.setMinimum(1)
+        self.num_repeats_per_point_box = QtWidgets.QSpinBox()
+        self.num_repeats_per_point_box.setMinimum(1)
         # A gratuitous, but hopefully generous restriction
-        self.repeat_each_point_box.setMaximum(2**16)
-        self.repeat_each_point_box.setValue(current_scan.get("repeat_point", 1))
-        repeat_each_point_layout.addWidget(self.repeat_each_point_box)
-        repeat_each_point_layout.setStretchFactor(self.repeat_each_point_box, 0)
-        repeat_each_point_layout.addStretch()
+        self.num_repeats_per_point_box.setMaximum(2**16)
+        self.num_repeats_per_point_box.setValue(current_scan.get("repeat_point", 1))
+        num_repeats_per_point_layout.addWidget(self.num_repeats_per_point_box)
+        num_repeats_per_point_layout.setStretchFactor(self.num_repeats_per_point_box, 0)
+        num_repeats_per_point_layout.addStretch()
 
         #
 
@@ -158,7 +158,7 @@ class ScanOptions:
 
     def get_widgets(self) -> list[QtWidgets.QWidget]:
         return [
-            self.num_repeats_container, self.repeat_each_point_container,
+            self.num_repeats_container, self.num_repeats_per_point_container,
             self.no_axis_container, self.randomise_globally_container,
             self.skip_persistently_failing_container
         ]
@@ -171,7 +171,7 @@ class ScanOptions:
         # multiple experiments if for whatever reason more repeats were required.
         scan["num_repeats"] = (2**31 - 1 if self.infinite_repeat_box.isChecked() else
                                self.num_repeats_box.value())
-        scan["repeat_each_point"] = self.repeat_each_point_box.value()
+        scan["num_repeats_per_point"] = self.num_repeats_per_point_box.value()
         scan["no_axes_mode"] = NoAxesMode(self.no_axes_box.currentText()).name
         scan["randomise_order_globally"] = self.randomise_globally_box.isChecked()
         scan["skip_on_persistent_transitory_error"] = (

--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -52,7 +52,7 @@ class ScanOptions:
         num_repeats_layout.setContentsMargins(5, 5, 5, 5)
         self.num_repeats_container.setLayout(num_repeats_layout)
 
-        num_repeats_label = QtWidgets.QLabel("Number of repeats: ")
+        num_repeats_label = QtWidgets.QLabel("Number of repeats of scan: ")
         num_repeats_layout.addWidget(num_repeats_label)
         num_repeats_layout.setStretchFactor(num_repeats_label, 0)
 
@@ -71,6 +71,27 @@ class ScanOptions:
         num_repeats_layout.addWidget(self.infinite_repeat_box)
         num_repeats_layout.setStretchFactor(self.infinite_repeat_box, 0)
         num_repeats_layout.addStretch()
+
+        #
+
+        self.repeat_each_point_container = QtWidgets.QWidget()
+        repeat_each_point_layout = QtWidgets.QHBoxLayout()
+        repeat_each_point_layout.setContentsMargins(5, 5, 5, 5)
+        self.repeat_each_point_container.setLayout(repeat_each_point_layout)
+
+        repeat_each_point_label = QtWidgets.QLabel(
+            "Number of consecutive repeats of each point: ")
+        repeat_each_point_layout.addWidget(repeat_each_point_label)
+        repeat_each_point_layout.setStretchFactor(repeat_each_point_label, 0)
+
+        self.repeat_each_point_box = QtWidgets.QSpinBox()
+        self.repeat_each_point_box.setMinimum(1)
+        # A gratuitous, but hopefully generous restriction
+        self.repeat_each_point_box.setMaximum(2**16)
+        self.repeat_each_point_box.setValue(current_scan.get("repeat_point", 1))
+        repeat_each_point_layout.addWidget(self.repeat_each_point_box)
+        repeat_each_point_layout.setStretchFactor(self.repeat_each_point_box, 0)
+        repeat_each_point_layout.addStretch()
 
         #
 
@@ -137,8 +158,9 @@ class ScanOptions:
 
     def get_widgets(self) -> list[QtWidgets.QWidget]:
         return [
-            self.num_repeats_container, self.no_axis_container,
-            self.randomise_globally_container, self.skip_persistently_failing_container
+            self.num_repeats_container, self.repeat_each_point_container,
+            self.no_axis_container, self.randomise_globally_container,
+            self.skip_persistently_failing_container
         ]
 
     def write_to_params(self, params: dict[str, Any]) -> None:
@@ -149,6 +171,7 @@ class ScanOptions:
         # multiple experiments if for whatever reason more repeats were required.
         scan["num_repeats"] = (2**31 - 1 if self.infinite_repeat_box.isChecked() else
                                self.num_repeats_box.value())
+        scan["repeat_each_point"] = self.repeat_each_point_box.value()
         scan["no_axes_mode"] = NoAxesMode(self.no_axes_box.currentText()).name
         scan["randomise_order_globally"] = self.randomise_globally_box.isChecked()
         scan["skip_on_persistent_transitory_error"] = (

--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -88,7 +88,8 @@ class ScanOptions:
         self.num_repeats_per_point_box.setMinimum(1)
         # A gratuitous, but hopefully generous restriction
         self.num_repeats_per_point_box.setMaximum(2**16)
-        self.num_repeats_per_point_box.setValue(current_scan.get("repeat_point", 1))
+        self.num_repeats_per_point_box.setValue(
+            current_scan.get("num_repeats_per_point", 1))
         num_repeats_per_point_layout.addWidget(self.num_repeats_per_point_box)
         num_repeats_per_point_layout.setStretchFactor(self.num_repeats_per_point_box, 0)
         num_repeats_per_point_layout.addStretch()

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -222,6 +222,7 @@ class ArgumentInterface(HasEnvironment):
             axes.append(ScanAxis(self._schemata[fqn], pathspec, store))
 
         options = ScanOptions(scan.get("num_repeats", 1),
+                              scan.get("repeat_each_point", 1),
                               scan.get("randomise_order_globally", False))
         spec = ScanSpec(axes, generators, options)
         no_axes_mode = NoAxesMode[scan.get("no_axes_mode", "single")]

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -222,7 +222,7 @@ class ArgumentInterface(HasEnvironment):
             axes.append(ScanAxis(self._schemata[fqn], pathspec, store))
 
         options = ScanOptions(scan.get("num_repeats", 1),
-                              scan.get("repeat_each_point", 1),
+                              scan.get("num_repeats_per_point", 1),
                               scan.get("randomise_order_globally", False))
         spec = ScanSpec(axes, generators, options)
         no_axes_mode = NoAxesMode[scan.get("no_axes_mode", "single")]

--- a/ndscan/experiment/scan_generator.py
+++ b/ndscan/experiment/scan_generator.py
@@ -242,7 +242,7 @@ class ScanOptions:
     #: How many times to repeat each point consecutively in a scan (i.e. without
     #: changing parameters). This is useful for scans where there is some settling time
     #: after moving to a new point.
-    repeat_each_point: int = 1
+    num_repeats_per_point: int = 1
 
     #: Whether to randomise the acquisition order of data points across all axes
     #: (within a refinement level).
@@ -294,7 +294,7 @@ def generate_points(axis_generators: list[ScanGenerator],
                 rng.shuffle(points)
 
             for p in points:
-                for _ in range(options.repeat_each_point):
+                for _ in range(options.num_repeats_per_point):
                     yield p[::-1]
 
         max_level += 1

--- a/ndscan/experiment/scan_generator.py
+++ b/ndscan/experiment/scan_generator.py
@@ -239,6 +239,11 @@ class ScanOptions:
     #: work when wanting to use repeats to gather statistical information.
     num_repeats: int = 1
 
+    #: How many times to repeat each point consecutively in a scan (i.e. without
+    #: changing parameters). This is useful for scans where there is some settling time
+    #: after moving to a new point.
+    repeat_each_point: int = 1
+
     #: Whether to randomise the acquisition order of data points across all axes
     #: (within a refinement level).
     #:
@@ -289,6 +294,7 @@ def generate_points(axis_generators: list[ScanGenerator],
                 rng.shuffle(points)
 
             for p in points:
-                yield p[::-1]
+                for _ in range(options.repeat_each_point):
+                    yield p[::-1]
 
         max_level += 1

--- a/ndscan/results/arguments.py
+++ b/ndscan/results/arguments.py
@@ -83,7 +83,8 @@ def dump_scan(schema: dict[str, Any]) -> Iterable[str]:
         path = ax["path"] or "*"
         yield f"   - {ps['description']} ({fqn}@{path}):"
         yield f"     {format_scan_range(ax['type'], ax['range'], ps)}"
-    yield f" - Number of repeats: {scan['num_repeats']}"
+    yield f" - Number of repeats of scan: {scan['num_repeats']}"
+    yield f" - Number of consecutive repeats of each point: {scan['repeat_each_point']}"
     yield f" - Randomise order globally: {scan['randomise_order_globally']}"
 
 

--- a/ndscan/results/arguments.py
+++ b/ndscan/results/arguments.py
@@ -84,7 +84,7 @@ def dump_scan(schema: dict[str, Any]) -> Iterable[str]:
         yield f"   - {ps['description']} ({fqn}@{path}):"
         yield f"     {format_scan_range(ax['type'], ax['range'], ps)}"
     yield f" - Number of repeats of scan: {scan['num_repeats']}"
-    yield f" - Number of consecutive repeats of each point: {scan['repeat_each_point']}"
+    yield f" - Number of repeats per point: {scan['num_repeats_per_point']}"
     yield f" - Randomise order globally: {scan['randomise_order_globally']}"
 
 

--- a/test/test_experiment_scan_generator.py
+++ b/test/test_experiment_scan_generator.py
@@ -1,6 +1,11 @@
 import numpy as np
 import unittest
-from ndscan.experiment.scan_generator import CentreSpanGenerator, ExpandingGenerator
+from ndscan.experiment.scan_generator import (
+    CentreSpanGenerator,
+    ExpandingGenerator,
+    generate_points,
+    ScanOptions,
+)
 
 
 class ScanGeneratorCase(unittest.TestCase):
@@ -117,3 +122,56 @@ class ScanGeneratorCase(unittest.TestCase):
         self.assertTrue(gen.has_level(0))
         self.assertEqual(gen.points_for_level(0), [-1.0, 0.0])
         self.assertFalse(gen.has_level(1))
+
+
+class GeneratePointsCase(unittest.TestCase):
+    def test_no_repeats(self):
+        opt = ScanOptions()
+        gen = CentreSpanGenerator(centre=0.0,
+                                  half_span=1.0,
+                                  num_points=2,
+                                  randomise_order=False)
+        points = list(generate_points([gen], opt))
+        self.assertEqual(points, [(-1.0, ), (1.0, )])
+
+    def test_repeat_scan(self):
+        opt = ScanOptions(num_repeats=2)
+        gen = CentreSpanGenerator(centre=0.0,
+                                  half_span=1.0,
+                                  num_points=2,
+                                  randomise_order=False)
+        points = list(generate_points([gen], opt))
+        self.assertEqual(points, [(-1.0, ), (1.0, ), (-1.0, ), (1.0, )])
+
+    def test_repeat_each_point(self):
+        opt = ScanOptions(num_repeats=1, num_repeats_per_point=2)
+        gen = CentreSpanGenerator(centre=0.0,
+                                  half_span=1.0,
+                                  num_points=2,
+                                  randomise_order=False)
+        points = list(generate_points([gen], opt))
+        self.assertEqual(points, [(-1.0, ), (-1.0, ), (1.0, ), (1.0, )])
+
+    def test_repeat_scan_and_each_point(self):
+        opt = ScanOptions(num_repeats=2, num_repeats_per_point=2)
+        gen = CentreSpanGenerator(centre=0.0,
+                                  half_span=1.0,
+                                  num_points=2,
+                                  randomise_order=False)
+        points = list(generate_points([gen], opt))
+        self.assertEqual(points, [(-1.0, ), (-1.0, ), (1.0, ), (1.0, ), (-1.0, ),
+                                  (-1.0, ), (1.0, ), (1.0, )])
+
+    def test_2d_scan(self):
+        opt = ScanOptions(num_repeats=1, num_repeats_per_point=1)
+        gen1 = CentreSpanGenerator(centre=0.0,
+                                   half_span=1.0,
+                                   num_points=2,
+                                   randomise_order=False)
+        gen2 = CentreSpanGenerator(centre=0.0,
+                                   half_span=20.0,
+                                   num_points=2,
+                                   randomise_order=False)
+        points = list(generate_points([gen1, gen2], opt))
+        self.assertEqual(points, [(-1.0, -20.0), (1.0, -20.0), (-1.0, 20.0),
+                                  (1.0, 20.0)])


### PR DESCRIPTION
This adds a scan option to repeat each point `n` times before moving on to the next point. Repeating the whole scan is not affected (you can repeat each point `n` time, and also repeat the whole scan `m` times).

This is useful for running scans where there is some settling time every time parameters are changed, without having to resort putting your own loops inside the fragments.
