### PR TITLE
plots: Make sure subscan plot objects are deleted after closing

### DIFF
--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -365,7 +365,7 @@ class SubplotMenuPanesWidget(ContextMenuPanesWidget):
             return
         self.subscan_plots[name] = plot
         plot.new_dock_requested.connect(self.new_dock_requested)
-        plot.was_closed.connect(lambda: self.subscan_plots.pop(name))
+        plot.was_closed.connect(lambda: self.subscan_plots.pop(name).deleteLater())
         self.new_dock_requested.emit(plot, f"subscan '{name}'")
 
     def close_subscan_plot(self, name):

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -213,10 +213,11 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
         super().__init__()
         self.model = model
 
-        # Since we are a QObject ourselves that will get QWidget.close()d, so destroyed
-        # on the C++ side, once we are removed from the UI, we can just connect to the
-        # model without worrying about what happens after the C++ part of the object is
-        # destructed, as the signals are automatically disconnected.
+        # Since we are a QObject ourselves, and the parents will make sure the widget is
+        # deleteLater()d on the on the C++ side once it is removed from the UI, we can
+        # just connect to the model without worrying about what happens after the C++
+        # part of the object is destructed, as the signals are automatically
+        # disconnected.
         self.model.channel_schemata_changed.connect(self._initialise_series),
         self.model.points_appended.connect(self._update_points),
         self.model.annotations_changed.connect(self._update_annotations),


### PR DESCRIPTION
I'd have liked to avoid the explicit deleteLater() call, but the
subplots were not properly cleaned up.

I am committing this long after making this change, and my notes on
this are not as good as I would like. To test this in the future,
add debug prints to check how many live model subscribers exist
(e.g. in the update…() slots), and make sure they do not accumulate
when closing/reopening subscans and toggling between top-level scan
points.
