### PR TITLE
plots: Avoid non-interactive black window when single-point scans have only subscans, but no channels

### DIFF
--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -357,7 +357,7 @@ class Image2DPlotWidget(ContextMenuPanesWidget):
                     self.y_schema["param"]["spec"]["members"].keys(), points["axis_1"])
             self.plot.data_changed(points, invalidate_previous=invalidate)
 
-    def build_context_menu(self, pane_idx: int, builder):
+    def build_context_menu(self, pane_idx: int | None, builder):
         if self.model.context.is_online_master():
             x_datasets = extract_linked_datasets(self.x_schema["param"])
             y_datasets = extract_linked_datasets(self.y_schema["param"])

--- a/ndscan/plots/model/subscan.py
+++ b/ndscan/plots/model/subscan.py
@@ -22,13 +22,16 @@ class SubscanRoot(Root):
             raise ValueError("Unexpected scan schema channel name: {}".format(
                 self._schema_key))
 
+        self._update(parent.get_point())
+
     def _update(self, data: dict[str, Any]) -> None:
         if data is None:
-            self._model.quit()
+            if self._model:
+                self._model.quit()
+                self.model_changed.emit(None)
             self._model = None
             self._schema = None
             self._schema_str = None
-            self.model_changed.emit(self._model)
             return
 
         schema_str = data[self._schema_key]

--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -323,18 +323,6 @@ class SubplotMenuPanesWidget(ContextMenuPanesWidget):
                     lambda *a, name=name: self._toggle_subscan_plot(name))
         super().build_context_menu(pane_idx, builder)
 
-    def open_subplot(self, name: str):
-        widget = self.subscan_plots.get(name, None)
-        if widget is not None:
-            widget.show()
-            widget.activateWindow()
-            return
-
-        import ndscan.plots.container_widgets as containers
-        widget = containers.RootWidget(self.subscan_roots[name])
-        self.subscan_plots[name] = widget
-        self.new_dock_requested.emit(widget, name)
-
     def _toggle_subscan_plot(self, name):
         toggle_all = (QtWidgets.QApplication.keyboardModifiers()
                       & QtCore.Qt.KeyboardModifier.ShiftModifier)

--- a/ndscan/plots/rolling_1d.py
+++ b/ndscan/plots/rolling_1d.py
@@ -183,7 +183,7 @@ class Rolling1DPlotWidget(SubplotMenuPanesWidget):
         points.extend(self._points)
         self._points = points
 
-    def build_context_menu(self, pane_idx: int, builder):
+    def build_context_menu(self, pane_idx: int | None, builder):
         if self.model.context.is_online_master():
             # If no new data points are coming in, setting the history size wouldn't do
             # anything.

--- a/ndscan/plots/rolling_1d.py
+++ b/ndscan/plots/rolling_1d.py
@@ -146,6 +146,22 @@ class Rolling1DPlotWidget(SubplotMenuPanesWidget):
 
         self.subscan_roots = create_subscan_roots(self.model)
 
+        if not self.panes and self.subscan_roots:
+            # If there aren't any panes, but there are subscans, show the subscans by
+            # default. This is useful in cases such as calibrations of vectorial
+            # quantities implemented using TopLevelRunners, where the useful plot shows
+            # the data acquisition subscan(s), but the top-level fragment does not have
+            # any non-opaque channels besides that.
+            for name in self.subscan_roots:
+                self.open_subscan_plot(name)
+
+            # KLUDGE: Reach into dock area to hide the useless empty plot widget where
+            # the top-level series (if any) would show up.
+            dock = self
+            while not isinstance(dock, pyqtgraph.dockarea.Dock):
+                dock = dock.parent()
+            dock.setStretch(0, 0)
+
         self.ready.emit()
 
     def _append_point(self, point):

--- a/ndscan/plots/rolling_1d.py
+++ b/ndscan/plots/rolling_1d.py
@@ -28,11 +28,9 @@ class _Series:
         self.set_history_length(history_length)
 
     def append(self, data):
-        new_data = data[self.data_name]
+        p = [data[self.data_name]]
         if self.error_bar_item:
-            new_error_bar = data[self.error_bar_name]
-
-        p = [new_data, 2 * new_error_bar] if self.error_bar_item else [new_data]
+            p.append(2 * data[self.error_bar_name])
 
         is_first = (self.values.shape[0] == 0)
         if is_first:

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -461,10 +461,10 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
                 logger.info("Ignoring annotation of kind '%s' with coordinates %s",
                             a.kind, list(a.coordinates.keys()))
 
-    def build_context_menu(self, pane_idx, builder):
+    def build_context_menu(self, pane_idx: int | None, builder):
         x_schema = self.model.axes[0]
 
-        if self.model.context.is_online_master():
+        if self.model.context.is_online_master() and pane_idx is not None:
             for d in extract_linked_datasets(x_schema["param"]):
                 action = builder.append_action(f"Set '{d}' from crosshair")
                 action.triggered.connect(


### PR DESCRIPTION
- **plots.plot_widget: Remove refactoring leftovers [nfc]**
- **plots.model.subscan: Fix single-point model subscans loaded from HDF5**
- **plots.rolling_1d: Show subscans if there are no channels**
- **plots: Show context menu also without panes**
- **plots.rolling_1d: Slight clean up [nfc]**
