### PR TITLE
plots.model: Fix online single-point scans with subscans

### DIFF
--- a/ndscan/plots/model/subscriber.py
+++ b/ndscan/plots/model/subscriber.py
@@ -85,8 +85,6 @@ class SubscriberSinglePointModel(SinglePointModel):
         return self._channel_schemata
 
     def get_point(self) -> dict[str, Any] | None:
-        if self._current_point is None:
-            raise ValueError("No complete point yet")
         return self._current_point
 
     def data_changed(self, values: dict[str, Any], mods: Iterable[dict[str,

--- a/test/test_plots_model_subscriber.py
+++ b/test/test_plots_model_subscriber.py
@@ -58,9 +58,8 @@ class SinglePointTest(unittest.TestCase):
         self.datasets["ndscan.point.foo"] = (False, 42, {})
         self.init()
 
-        with self.assertRaises(ValueError):
-            # No complete point yet.
-            self.root.get_model().get_point()
+        # No complete point yet.
+        self.assertIsNone(self.root.get_model().get_point())
 
         self.datasets["ndscan.point.bar"] = (False, 23, {})
         self.datasets["ndscan.point_phase"] = (False, True, {})
@@ -71,9 +70,8 @@ class SinglePointTest(unittest.TestCase):
         self.datasets["ndscan.point.foo"] = (False, 42, {})
         self.init()
 
-        with self.assertRaises(ValueError):
-            # No complete point yet.
-            self.root.get_model().get_point()
+        # No complete point yet.
+        self.assertIsNone(self.root.get_model().get_point())
 
         self.datasets["ndscan.point.bar"] = (False, 23, {})
         self.datasets["ndscan.point_phase"] = (False, True, {})
@@ -92,9 +90,8 @@ class SinglePointTest(unittest.TestCase):
         self.datasets["ndscan.point.foo"] = (False, 0, {})
         self.init()
 
-        with self.assertRaises(ValueError):
-            # Can't know whether point is complete (it indeed isn't).
-            self.root.get_model().get_point()
+        # Can't know whether point is complete (it indeed isn't).
+        self.assertIsNone(self.root.get_model().get_point())
 
         self.datasets["ndscan.point.bar"] = (False, 1, {})
         self.datasets["ndscan.point_phase"] = (False, False, {})


### PR DESCRIPTION
Commit 47bfa82c changed SubscanModel to eagerly fetch the current point,
in line with the earlier changes away from deferred initialisation of
the model contents. Now (as in this case), querying an incomplete model
for get_point() is not an error anymore, as reflected in the | None
return type.
