### PR TITLE
plot_widgets: Fix submenus for context menus outside plot item

### DIFF
--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -248,10 +248,10 @@ class ContextMenuBuilder:
 
     def append_menu(self, title) -> QtWidgets.QMenu:
         menu = QtWidgets.QMenu(title, parent=self._target_menu)
-        self._append(menu)
+        self._append(menu.menuAction())
         return menu
 
-    def _append(self, action):
+    def _append(self, action: QtGui.QAction):
         self._last_was_no_separator = True
         self._entries.append(action)
 


### PR DESCRIPTION
This only concerns the implementation for context menus outside
any plot panes added in 90f19ca; pyqtgraph's raiseContextMenu()
implementation already takes care of this conversion.
