### PR TITLE
results: dump_scan() backwards compatibilty for per-point repeats

### DIFF
--- a/ndscan/results/arguments.py
+++ b/ndscan/results/arguments.py
@@ -84,7 +84,7 @@ def dump_scan(schema: dict[str, Any]) -> Iterable[str]:
         yield f"   - {ps['description']} ({fqn}@{path}):"
         yield f"     {format_scan_range(ax['type'], ax['range'], ps)}"
     yield f" - Number of repeats of scan: {scan['num_repeats']}"
-    yield f" - Number of repeats per point: {scan['num_repeats_per_point']}"
+    yield f" - Number of repeats per point: {scan.get('num_repeats_per_point', 1)}"
     yield f" - Randomise order globally: {scan['randomise_order_globally']}"
 
 


### PR DESCRIPTION
This makes e.g. ndscan_show compatible with results files from before
num_repeats_per_point was added.

In general, the analysis tools should strive to be backwards-compatible
across all but the most egregious schema changes.
