### PR TITLE
pyproject.toml: Remove uv_build version bounds for Nix compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ oitg = { git = "https://github.com/oxfordiontrapgroup/oitg.git" }
 sipyco = { git = "https://github.com/m-labs/sipyco.git" }
 
 [build-system]
-requires = ["uv_build>=0.7.19,<0.8.0"]
+requires = ["uv_build"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
Nixpkgs as pulled in via ARTIQ currently has 0.7.3. Since I don't have a
good idea what the compatibility story for uv_build is going to be, I
just removed the bounds altogether for now. We might want to revisit
this in the future, e.g. to >=0.7.3,<0.8.
