### PR TITLE
deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ dev = [
 [tool.uv.sources]
 artiq = { git = "https://github.com/m-labs/artiq.git", branch = "release-8" }
 oitg = { git = "https://github.com/oxfordiontrapgroup/oitg.git" }
-sipyco = { git = "https://github.com/m-labs/sipyco.git" }
+
+#.Pin SiPyCo to v1.9 for now to avoid PYON v2 fiasco (silent, breaking format change).
+sipyco = { git = "https://github.com/m-labs/sipyco.git", tag = "v1.9" }
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,10 @@ oitg = { git = "https://github.com/oxfordiontrapgroup/oitg.git" }
 #.Pin SiPyCo to v1.9 for now to avoid PYON v2 fiasco (silent, breaking format change).
 sipyco = { git = "https://github.com/m-labs/sipyco.git", tag = "v1.9" }
 
+# Avoid frequent crashes due to QMutexLocker memory corruption/race condition; see
+# CabbageDevelopment/qasync#128. Can be removed once there is a released version.
+qasync = { git = "https://github.com/dnadlinger/qasync.git", branch = "windows-qmutexlocker-fix" }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -922,7 +922,7 @@ requires-dist = [
     { name = "oitg", git = "https://github.com/oxfordiontrapgroup/oitg.git" },
     { name = "pyqt6", specifier = ">=6.5.2" },
     { name = "pyqtgraph", specifier = ">=0.13.3" },
-    { name = "qasync", specifier = ">=0.27.1" },
+    { name = "qasync", git = "https://github.com/dnadlinger/qasync.git?branch=windows-qmutexlocker-fix" },
     { name = "sipyco", git = "https://github.com/m-labs/sipyco.git?tag=v1.9" },
 ]
 
@@ -1542,12 +1542,8 @@ wheels = [
 
 [[package]]
 name = "qasync"
-version = "0.27.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/e0/7c7c973f52e1765d6ddfc41e9272294f65d5d52b8f5f5eae92adf411ad46/qasync-0.27.1.tar.gz", hash = "sha256:8dc768fd1ee5de1044c7c305eccf2d39d24d87803ea71189d4024fb475f4985f", size = 14287, upload-time = "2023-11-19T14:19:55.535Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/06/bc628aa2981bcfd452a08ee435b812fd3eee4ada8acb8a76c4a09d1a5a77/qasync-0.27.1-py3-none-any.whl", hash = "sha256:5d57335723bc7d9b328dadd8cb2ed7978640e4bf2da184889ce50ee3ad2602c7", size = 14866, upload-time = "2023-11-19T14:19:54.345Z" },
-]
+version = "0.27.2"
+source = { git = "https://github.com/dnadlinger/qasync.git?branch=windows-qmutexlocker-fix#5f99e2bf2d53cf82366c61445d74bc01ea250f84" }
 
 [[package]]
 name = "rapidfuzz"

--- a/uv.lock
+++ b/uv.lock
@@ -923,7 +923,7 @@ requires-dist = [
     { name = "pyqt6", specifier = ">=6.5.2" },
     { name = "pyqtgraph", specifier = ">=0.13.3" },
     { name = "qasync", specifier = ">=0.27.1" },
-    { name = "sipyco", git = "https://github.com/m-labs/sipyco.git" },
+    { name = "sipyco", git = "https://github.com/m-labs/sipyco.git?tag=v1.9" },
 ]
 
 [package.metadata.requires-dev]
@@ -1863,7 +1863,7 @@ wheels = [
 [[package]]
 name = "sipyco"
 version = "1.9"
-source = { git = "https://github.com/m-labs/sipyco.git#8781f35879855aba29038f0b32ecfa2c398b5ac9" }
+source = { git = "https://github.com/m-labs/sipyco.git?tag=v1.9#72dd23a358b72b2a73dc02780137750630071d98" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },


### PR DESCRIPTION
- **pyproject: Pin sipyco to v1.9 to avoid PYONv2 fiasco**
- **pyproject.toml: Pull in pre-release version of qasync with Windows fix**
