### PR TITLE
Slice 2D scan plots along an axis

### DIFF
--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -6,16 +6,21 @@ from itertools import chain, repeat
 import numpy as np
 import pyqtgraph
 
+from ndscan.plots.model.select_point import SelectPointFromScanModel
+from ndscan.plots.model.subscan import create_subscan_roots
+
 from .._qt import QtCore, QtGui
 from . import colormaps
 from .cursor import CrosshairAxisLabel, CrosshairLabel, LabeledCrosshairCursor
 from .model import ScanModel
-from .plot_widgets import ContextMenuPanesWidget, add_source_id_label
+from .plot_widgets import SubplotMenuPanesWidget, add_source_id_label
 from .utils import (
+    HIGHLIGHT_PEN,
     call_later,
     enum_to_numeric,
     extract_linked_datasets,
     extract_scalar_channels,
+    find_neighbour_index,
     format_param_identity,
     get_axis_scaling_info,
     setup_axis_item,
@@ -61,7 +66,6 @@ def _coords_to_indices(coords, range_spec):
 
 class CrosshairZDataLabel(CrosshairLabel):
     """Crosshair label for the z value of a 2D image"""
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.x_range = None
@@ -114,10 +118,21 @@ class CrosshairZDataLabel(CrosshairLabel):
             self.set_value(z, self.z_limits)
 
 
+class ClickableImageItem(pyqtgraph.ImageItem):
+    """An ImageItem that emits a signal when clicked."""
+
+    sigClicked = QtCore.pyqtSignal(QtCore.QPointF)
+
+    def mouseClickEvent(self, event):
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
+            self.sigClicked.emit(event.pos())
+            event.accept()
+
+
 class _ImagePlot:
     def __init__(
         self,
-        image_item: pyqtgraph.ImageItem,
+        image_item: ClickableImageItem,
         colorbar: pyqtgraph.ColorBarItem,
         active_channel_name: str,
         x_min: float | None,
@@ -214,9 +229,9 @@ class _ImagePlot:
 
         # Update running averages.
         for x, y, z in zip(
-            x_data[num_skip:num_to_show],
-            y_data[num_skip:num_to_show],
-            z_data[num_skip:num_to_show],
+                x_data[num_skip:num_to_show],
+                y_data[num_skip:num_to_show],
+                z_data[num_skip:num_to_show],
         ):
             avg, num = self.averages_by_coords.get((x, y), (0.0, 0))
             num += 1
@@ -238,12 +253,10 @@ class _ImagePlot:
             )
 
             self.image_rect = QtCore.QRectF(
-                QtCore.QPointF(
-                    x_range[0] - x_range[2] / 2, y_range[0] - y_range[2] / 2
-                ),
-                QtCore.QPointF(
-                    x_range[1] + x_range[2] / 2, y_range[1] + y_range[2] / 2
-                ),
+                QtCore.QPointF(x_range[0] - x_range[2] / 2,
+                               y_range[0] - y_range[2] / 2),
+                QtCore.QPointF(x_range[1] + x_range[2] / 2,
+                               y_range[1] + y_range[2] / 2),
             )
 
             num_skip = 0
@@ -287,7 +300,7 @@ class _ImagePlot:
         self.averaging_enabled = averaging_enabled
 
 
-class Image2DPlotWidget(ContextMenuPanesWidget):
+class Image2DPlotWidget(SubplotMenuPanesWidget):
     def __init__(self, model: ScanModel):
         super().__init__()
 
@@ -295,6 +308,8 @@ class Image2DPlotWidget(ContextMenuPanesWidget):
         self.model.channel_schemata_changed.connect(self._initialise_series)
         self.model.points_appended.connect(lambda p: self._update_points(p, False))
         self.model.points_rewritten.connect(lambda p: self._update_points(p, True))
+
+        self.selected_point_model = SelectPointFromScanModel(self.model)
 
         self.data_names = []
 
@@ -319,6 +334,8 @@ class Image2DPlotWidget(ContextMenuPanesWidget):
             self.plot.image_item.destroyLater()
             self.plot = None
 
+        self.subscan_roots = create_subscan_roots(self.selected_point_model)
+
         try:
             self.data_names, _ = extract_scalar_channels(channels)
         except ValueError as e:
@@ -331,15 +348,13 @@ class Image2DPlotWidget(ContextMenuPanesWidget):
             param = schema["param"]
             setup_axis_item(
                 self.plot_item.getAxis(location),
-                [
-                    (
-                        param["description"],
-                        format_param_identity(schema),
-                        param["type"],
-                        None,
-                        param["spec"],
-                    )
-                ],
+                [(
+                    param["description"],
+                    format_param_identity(schema),
+                    param["type"],
+                    None,
+                    param["spec"],
+                )],
             )
 
         setup_axis(self.x_schema, "bottom")
@@ -348,7 +363,9 @@ class Image2DPlotWidget(ContextMenuPanesWidget):
         def bounds(schema):
             return (schema.get(n, None) for n in ("min", "max", "increment"))
 
-        image_item = pyqtgraph.ImageItem()
+        image_item = ClickableImageItem()
+        image_item.sigClicked.connect(self._point_clicked)
+
         self.plot_item.addItem(image_item)
         colorbar = self.plot_item.addColorBar(image_item, width=15.0, interactive=False)
         self.plot = _ImagePlot(
@@ -359,6 +376,14 @@ class Image2DPlotWidget(ContextMenuPanesWidget):
             *bounds(self.y_schema),
             channels,
         )
+
+        highlight_pen = pyqtgraph.mkPen(**HIGHLIGHT_PEN)
+        self.highlight_point_item = pyqtgraph.ScatterPlotItem(pen=highlight_pen,
+                                                              brush=None,
+                                                              size=8,
+                                                              symbol="o")
+        self.highlight_point_item.setZValue(2)  # Show above all other points.
+        self.plot_item.addItem(self.highlight_point_item)
 
         x_scaling_info = get_axis_scaling_info(self.x_schema["param"]["spec"])
         y_scaling_info = get_axis_scaling_info(self.y_schema["param"]["spec"])
@@ -375,6 +400,8 @@ class Image2DPlotWidget(ContextMenuPanesWidget):
         )
 
         add_source_id_label(self.plot_item.getViewBox(), self.model.context)
+
+        self.subscan_roots = create_subscan_roots(self.selected_point_model)
 
         self.ready.emit()
 
@@ -452,6 +479,100 @@ class Image2DPlotWidget(ContextMenuPanesWidget):
         if not self.plot:
             logger.warning("Plot not initialised yet, ignoring set dataset request")
             return
-        self.model.context.set_dataset(
-            dataset, self.crosshair.labels[axis_idx].last_value
-        )
+        self.model.context.set_dataset(dataset,
+                                       self.crosshair.labels[axis_idx].last_value)
+
+    def _point_clicked(self, pos: QtCore.QPointF):
+        x_idx = np.floor(pos.x())
+        y_idx = np.floor(pos.y())
+        x = self.plot.x_range[0] + x_idx * self.plot.x_range[2]
+        y = self.plot.y_range[0] + y_idx * self.plot.y_range[2]
+
+        source_idx = self._xy_to_source_index(x, y)
+        self._highlight_index(source_idx)
+
+    def _xy_to_source_index(self, x, y) -> int | None:
+        x_source = self.plot.points["axis_0"]
+        y_source = self.plot.points["axis_1"]
+
+        source_idx = np.flatnonzero(np.logical_and(x_source == x, y_source == y))
+
+        if source_idx.size == 0:
+            return None
+
+        # FIXME: Does not handle duplicate coordinates correctly.
+        return source_idx[0]
+
+    def _get_highlighted_neighbour_index(self, axis: int, step: int) -> int | None:
+        current_x, current_y = self._highlighted_xy
+
+        if not self.plot or self._highlighted_xy == (None, None):
+            return None
+
+        x_source = np.asarray(self.plot.points["axis_0"])
+        y_source = np.asarray(self.plot.points["axis_1"])
+
+        def _get_nearest(
+            sliced_axis_coord,
+            fixed_axis_coord,
+            sliced_axis_source,
+            fixed_axis_source,
+        ):
+            sliced_indices = np.flatnonzero(fixed_axis_source == fixed_axis_coord)
+            _sliced_source = sliced_axis_source[sliced_indices]
+
+            # Doesn't matter if the coordinates are duplicated here --
+            # the first occurrence is as good as any.
+            idx_along_slice = np.flatnonzero(_sliced_source == sliced_axis_coord)[0]
+            neighbour = _sliced_source[find_neighbour_index(_sliced_source,
+                                                            idx_along_slice, step)]
+            return np.flatnonzero(
+                np.logical_and(
+                    sliced_axis_source == neighbour,
+                    fixed_axis_source == fixed_axis_coord,
+                ))[0]
+
+        if axis == 0:
+            return _get_nearest(current_x, current_y, x_source, y_source)
+        elif axis == 1:
+            return _get_nearest(current_y, current_x, y_source, x_source)
+
+    def _highlight_index(self, source_idx: int | None):
+        self.selected_point_model.set_source_index(source_idx)
+
+        if source_idx is None and self.highlight_point_item.parentItem():
+            self.plot_item.removeItem(self.highlight_point_item)
+            self._highlighted_xy = (None, None)
+        else:
+            x = self.plot.points["axis_0"][source_idx]
+            y = self.plot.points["axis_1"][source_idx]
+
+            if source_idx is None:
+                return
+
+            self.highlight_point_item.setData([x], [y], data=source_idx)
+            self._highlighted_xy = (x, y)
+            if not self.highlight_point_item.parentItem():
+                # Add with ignoreBounds=True to avoid highlighting an edge point causing
+                # the entire plot to shift in auto-range mode.
+                self.plot_item.addItem(self.highlight_point_item, ignoreBounds=True)
+
+    def keyPressEvent(self, event):
+        key = event.key()
+        is_left = key == QtCore.Qt.Key.Key_Left
+        is_right = key == QtCore.Qt.Key.Key_Right
+        is_up = key == QtCore.Qt.Key.Key_Up
+        is_down = key == QtCore.Qt.Key.Key_Down
+
+        if is_left or is_right:
+            axis = 0
+        elif is_up or is_down:
+            axis = 1
+        else:
+            return super().keyPressEvent(event)
+
+        step = -1 if is_left or is_down else 1
+        neighbour_idx = self._get_highlighted_neighbour_index(axis, step)
+        if neighbour_idx is not None:
+            self._highlight_index(neighbour_idx)
+        event.accept()

--- a/ndscan/plots/model/select_point.py
+++ b/ndscan/plots/model/select_point.py
@@ -25,6 +25,9 @@ class SelectPointFromScanModel(SinglePointModel):
             return
         self._set_point(idx, silently_fail=False)
 
+    def get_source_index(self) -> int | None:
+        return self._source_index
+
     def get_channel_schemata(self) -> dict[str, Any]:
         return self._source.get_channel_schemata()
 

--- a/ndscan/plots/model/slice.py
+++ b/ndscan/plots/model/slice.py
@@ -1,0 +1,177 @@
+import logging
+from typing import Any
+
+import numpy as np
+
+from ..utils import slice_data_along_axis
+from . import Model, Root, ScanModel
+from .select_point import SelectPointFromScanModel
+
+logger = logging.getLogger(__name__)
+
+
+class SliceRoot(Root):
+    def __init__(
+        self,
+        parent: ScanModel,
+        selected_point: SelectPointFromScanModel,
+        channel_schemata: dict[str, Any],
+        axis_idx: int,
+    ):
+        super().__init__()
+        self.axis_idx = axis_idx
+
+        self._parent = parent
+        self._selected_point = selected_point
+        self._channel_schemata = channel_schemata
+        self._model = None
+
+        self._selected_point = None
+        self.set_selected_point(selected_point)
+
+    def _update(self, *_args) -> None:
+        fixed_point_idx = self._selected_point.get_source_index()
+
+        # No point selected; clear model.
+        if fixed_point_idx is None:
+            if self._model:
+                self._model.quit()
+                self.model_changed.emit(None)
+            self._model = None
+            return
+
+        if self._model is None:
+            self._model = SliceForScanModel(
+                self._parent, self.axis_idx, self._selected_point
+            )
+            self.model_changed.emit(self._model)
+
+    def get_model(self) -> Model | None:
+        return self._model
+
+    def get_selected_point(self) -> SelectPointFromScanModel:
+        return self._selected_point
+
+    def set_selected_point(self, selected_point: SelectPointFromScanModel) -> None:
+        self._selected_point = selected_point
+        self._selected_point.point_changed.connect(self._update)
+        self._update()
+
+
+class SliceForScanModel(ScanModel):
+    """A 1-dimensional slice of an N-dimensional scan.
+
+    Point content changes are forwarded, but the schema is static; changes to the latter
+    necessitate a new model instance.
+    """
+
+    def __init__(
+        self,
+        parent: ScanModel,
+        axis_idx: int,
+        fixed_point: SelectPointFromScanModel,
+    ):
+        """
+        Slice a parent N-dimensional scan model along `axis_idx` through `fixed_point`.
+
+        :param parent: The parent scan model.
+        :param axis_idx: The index of the slicing axis
+            (i.e. along which the coordinates vary).
+        :param fixed_point: A model giving the fixed coordinates for the other axes.
+        """
+
+        self._parent = parent
+        self._axis_idx = axis_idx
+        self._fixed_point = fixed_point
+        self._channel_schemata = self._parent.get_channel_schemata()
+
+        axes = [self._parent.axes[self._axis_idx]]
+        super().__init__(axes, parent.schema_revision, parent.context)
+
+        self._sliced_data = {}
+
+        self._fixed_point.point_changed.connect(self._update)
+        self._parent.points_appended.connect(self._update)
+        self._parent.points_rewritten.connect(self._update)
+        self._update()
+
+    def _update(self, *_args) -> None:
+        parent_data = self._parent.get_point_data()
+        fixed_point_idx = self._fixed_point.get_source_index()
+        sliced_data = self.slice_data(parent_data, fixed_point_idx)
+
+        data_rewritten = False
+        for name, incoming_values in sliced_data.items():
+            # Check if points were appended or rewritten.
+            if name in self._sliced_data:
+                imax = min(len(incoming_values), len(self._sliced_data[name]))
+                if not np.array_equal(
+                    incoming_values[:imax], self._sliced_data[name][:imax]
+                ):
+                    data_rewritten = True
+
+        if self._sliced_data == sliced_data:
+            return
+
+        self._sliced_data = sliced_data
+
+        if data_rewritten:
+            self.points_rewritten.emit(self._sliced_data)
+        else:
+            self.points_appended.emit(self._sliced_data)
+
+    def slice_data(
+        self,
+        source_data: dict[str, Any],
+        fixed_point_idx: int | None,
+    ) -> dict[str, Any]:
+        """Extract the sliced data from the parent point data.
+
+        :param source_data: The point data from the parent model.
+        :param fixed_point_idx: The index of the fixed point in the parent data.
+        :return: The sliced point data.
+        """
+        if source_data is None or fixed_point_idx is None:
+            return {"axis_0": []}
+
+        sliced_data = {}
+        slice_indices = slice_data_along_axis(
+            source_data, fixed_point_idx, self._axis_idx
+        )
+
+        sliced_data["axis_0"] = np.asarray(source_data[f"axis_{self._axis_idx}"])[
+            slice_indices
+        ].tolist()
+
+        for name, values in source_data.items():
+            if not name.startswith("axis_"):
+                sliced_data[name] = np.asarray(values)[slice_indices].tolist()
+
+        return sliced_data
+
+    def get_channel_schemata(self) -> dict[str, Any]:
+        return self._channel_schemata
+
+    def get_point_data(self) -> dict[str, Any]:
+        return self._sliced_data
+
+    def quit(self) -> None:
+        self._parent.points_appended.disconnect(self._update)
+        self._parent.points_rewritten.disconnect(self._update)
+        self._fixed_point.point_changed.disconnect(self._update)
+
+
+def create_slice_roots(
+    model: ScanModel, selected_point: SelectPointFromScanModel
+) -> dict[str, SliceRoot]:
+    schemata = model.get_channel_schemata()
+    if schemata is None:
+        return {}
+
+    result = {}
+    model.get_point_data()
+    for i, axis in enumerate(model.axes):
+        name = axis.get("param", {}).get("description", "axis_{}".format(i))
+        root = SliceRoot(model, selected_point, schemata, i)
+        result[name] = root
+    return result


### PR DESCRIPTION
Adds support for viewing 1D slices of 2D scans along a specified axis. Also works with subscans

Supersedes #465
Implements #429 
