### PR TITLE
argument editor: Add support for tooltips to param labels

### DIFF
--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -453,7 +453,7 @@ class ArgumentEditor(QtWidgets.QTreeWidget, OverrideProvider):
         if explanation := schema.get("explanation", ""):
             label.setToolTip(explanation)
         else:
-            label.setToolTip(schema["description"])
+            label.setToolTip(schema["description"] + " (no <i>explanation</i> set)")
 
         # For whatever reason, the auto-sized column is not wide enough to display the
         # whole label if displayed through a widget – whether through an extra

--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -450,6 +450,11 @@ class ArgumentEditor(QtWidgets.QTreeWidget, OverrideProvider):
         label.setFont(font)
         label_container.addWidget(label)
 
+        if explanation := schema.get("explanation", ""):
+            label.setToolTip(explanation)
+        else:
+            label.setToolTip(schema["description"])
+
         # For whatever reason, the auto-sized column is not wide enough to display the
         # whole label if displayed through a widget – whether through an extra
         # LayoutWidget or the QLabel directly. This does not occur when passing a string

--- a/ndscan/dashboard/param_tree_dialog.py
+++ b/ndscan/dashboard/param_tree_dialog.py
@@ -229,6 +229,8 @@ class ParamTreeDialog(QtWidgets.QDialog):
             extras.append(range_extras)
         html += "</p><p>".join("<br>".join(e) for e in extras)
         html += "</p>"
+        if explanation := schema.get("explanation"):
+            html += f"<p>Explanation: {explanation}</p>"
         self.text_edit.setHtml(html)
 
         override_status = self.override_provider.override_status(fqn, path)

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -384,6 +384,7 @@ class FloatParam(ParamBase):
         scale: float | None = None,
         step: float | None = None,
         is_scannable: bool = True,
+        explanation: str = "",
     ):
         ParamBase.__init__(
             self,
@@ -396,6 +397,7 @@ class FloatParam(ParamBase):
             scale=scale,
             step=step,
             is_scannable=is_scannable,
+            explanation=explanation,
         )
         self.scale = resolve_numeric_scale(scale, unit)
         self.step = step if step is not None else self.scale / 10.0
@@ -420,6 +422,7 @@ class FloatParam(ParamBase):
             "type": "float",
             "default": str(self.default),
             "spec": spec,
+            "explanation": self.explanation,
         }
 
     def eval_default(self, get_dataset: GetDataset) -> float:
@@ -459,6 +462,7 @@ class IntParam(ParamBase):
         unit: str = "",
         scale: int | None = None,
         is_scannable: bool = True,
+        explanation: str = "",
     ):
         ParamBase.__init__(
             self,
@@ -470,6 +474,7 @@ class IntParam(ParamBase):
             unit=unit,
             scale=scale,
             is_scannable=is_scannable,
+            explanation=explanation,
         )
         self.scale = resolve_numeric_scale(scale, unit)
         if self.scale != 1:
@@ -494,6 +499,7 @@ class IntParam(ParamBase):
             "type": "int",
             "default": str(self.default),
             "spec": spec,
+            "explanation": self.explanation,
         }
 
     def eval_default(self, get_dataset: GetDataset) -> int:
@@ -528,7 +534,13 @@ class StringParam(ParamBase):
     CompilerType = str  # deprecated (not used in ndscan anymore); will go away
 
     def __init__(
-        self, fqn: str, description: str, default: str, is_scannable: bool = True
+        self,
+        fqn: str,
+        description: str,
+        default: str,
+        is_scannable: bool = True,
+        *,
+        explanation: str = "",
     ):
         try:
             eval_param_default(default, _raise_not_implemented)
@@ -550,6 +562,7 @@ class StringParam(ParamBase):
             description=description,
             default=default,
             is_scannable=is_scannable,
+            explanation=explanation,
         )
 
     def describe(self) -> dict[str, Any]:
@@ -560,6 +573,7 @@ class StringParam(ParamBase):
             "type": "string",
             "default": str(self.default),
             "spec": {"is_scannable": self.is_scannable},
+            "explanation": self.explanation,
         }
 
     def eval_default(self, get_dataset: GetDataset) -> str:
@@ -579,10 +593,20 @@ class BoolParam(ParamBase):
     CompilerType = bool  # deprecated (not used in ndscan anymore); will go away
 
     def __init__(
-        self, fqn: str, description: str, default: str | bool, is_scannable: bool = True
+        self,
+        fqn: str,
+        description: str,
+        default: str | bool,
+        is_scannable: bool = True,
+        *,
+        explanation: str = "",
     ):
         super().__init__(
-            fqn=fqn, description=description, default=default, is_scannable=is_scannable
+            fqn=fqn,
+            description=description,
+            default=default,
+            is_scannable=is_scannable,
+            explanation=explanation,
         )
 
     def describe(self) -> dict[str, Any]:
@@ -593,6 +617,7 @@ class BoolParam(ParamBase):
             "type": "bool",
             "default": str(self.default),
             "spec": {"is_scannable": self.is_scannable},
+            "explanation": self.explanation,
         }
 
     def eval_default(self, get_dataset: GetDataset) -> bool:
@@ -687,6 +712,8 @@ class EnumParam(ParamBase):
         default: Enum | str,
         enum_class: type[Enum] | None = None,
         is_scannable: bool = True,
+        *,
+        explanation: str = "",
     ):
         if enum_class is None:
             if isinstance(default, Enum):
@@ -717,6 +744,7 @@ class EnumParam(ParamBase):
             default=default,
             enum_class=enum_class,
             is_scannable=is_scannable,
+            explanation=explanation,
         )
 
     def describe(self) -> dict[str, Any]:
@@ -740,6 +768,7 @@ class EnumParam(ParamBase):
             "type": "enum",
             "default": default,
             "spec": {"members": members, "is_scannable": self.is_scannable},
+            "explanation": self.explanation,
         }
 
     def eval_default(self, get_dataset: GetDataset) -> Enum:

--- a/test/test_experiment_entrypoint.py
+++ b/test/test_experiment_entrypoint.py
@@ -164,6 +164,7 @@ class FragmentScanExpCase(HasEnvironmentCase):
                         "step": 0.1,
                     },
                     "type": "float",
+                    "explanation": "",
                 },
                 "path": "*",
             }
@@ -258,6 +259,7 @@ class FragmentScanExpCase(HasEnvironmentCase):
                         "unit": "ms",
                     },
                     "type": "float",
+                    "explanation": "",
                 },
                 "path": "*",
             }

--- a/test/test_experiment_parameters.py
+++ b/test/test_experiment_parameters.py
@@ -89,6 +89,7 @@ class FloatParamCase(GenericBase.Cases):
         "max": 2.0,
         "unit": "baz",
         "scale": 1.0,
+        "explanation": "barbarbar",
     }
     EXPECTED_DESCRIPTION = {
         "description": "bar",
@@ -102,6 +103,7 @@ class FloatParamCase(GenericBase.Cases):
             "step": 0.1,
             "is_scannable": True,
         },
+        "explanation": "barbarbar",
     }
 
 
@@ -116,6 +118,7 @@ class IntParamCase(GenericBase.Cases):
         "max": 1,
         "unit": "baz",
         "scale": 1,
+        "explanation": "barbarbar",
     }
     EXPECTED_DESCRIPTION = {
         "description": "bar",
@@ -128,6 +131,7 @@ class IntParamCase(GenericBase.Cases):
             "scale": 1,
             "is_scannable": True,
         },
+        "explanation": "barbarbar",
     }
 
 
@@ -138,6 +142,7 @@ class StringParamCase(GenericBase.Cases):
     EXAMPLE_KWARGS = {
         "description": "baz",
         "default": "'foo'",
+        "explanation": "barbarbar",
     }
     EXPECTED_DESCRIPTION = {
         "description": "baz",
@@ -146,6 +151,7 @@ class StringParamCase(GenericBase.Cases):
         "spec": {
             "is_scannable": True,
         },
+        "explanation": "barbarbar",
     }
 
     def to_dataset_value(self, x):
@@ -164,6 +170,7 @@ class BoolParamCase(GenericBase.Cases):
     EXAMPLE_KWARGS = {
         "description": "bar",
         "default": True,
+        "explanation": "barbarbar",
     }
     EXPECTED_DESCRIPTION = {
         "description": "bar",
@@ -172,6 +179,7 @@ class BoolParamCase(GenericBase.Cases):
         "spec": {
             "is_scannable": True,
         },
+        "explanation": "barbarbar",
     }
 
 
@@ -190,12 +198,14 @@ class EnumParamElemCase(GenericBase.Cases):
     EXAMPLE_KWARGS = {
         "description": "bar",
         "default": Options.first,
+        "explanation": "barbarbar",
     }
     EXPECTED_DESCRIPTION = {
         "description": "bar",
         "type": "enum",
         "default": "'first'",
         "spec": {"members": {o.name: o.value for o in Options}, "is_scannable": True},
+        "explanation": "barbarbar",
     }
 
     def to_dataset_value(self, x):
@@ -220,6 +230,7 @@ class EnumParamStringCase(GenericBase.Cases):
         "type": "enum",
         "default": "'first'",
         "spec": {"members": {o.name: o.value for o in Options}, "is_scannable": True},
+        "explanation": "",
     }
 
     def to_dataset_value(self, x):

--- a/test/test_experiment_subscan.py
+++ b/test/test_experiment_subscan.py
@@ -147,6 +147,7 @@ class SubscanCase(ExpFragmentCase):
                         "fqn": "fixtures.AddOneFragment.value",
                         "spec": {"is_scannable": True, "scale": 1.0, "step": 0.1},
                         "type": "float",
+                        "explanation": "",
                     },
                     "increment": 1.0,
                 }


### PR DESCRIPTION
Thought it would be nice to allow more verbose descriptions in a tooltip on parameter labels like vanilla artiq