### PR TITLE
experiment: Also catch missing/duplicate result push()es in no-axis (single/time series) mode

### DIFF
--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -592,6 +592,7 @@ class _NoAxisRunner(HasEnvironment):
 
     @portable
     def _run_loop(self):
+        self._install_result_batcher()
         try:
             while not self.scheduler.check_pause():
                 try:
@@ -647,12 +648,24 @@ class _NoAxisRunner(HasEnvironment):
                     )
             return False
         finally:
+            self._remove_result_batcher()
             self.fragment.device_cleanup()
         assert False, "Execution never reaches here, return is just to pacify compiler."
         return True
 
     @rpc(flags={"async"})
+    def _install_result_batcher(self):
+        self._result_batcher = ResultBatcher(self.fragment)
+        self._result_batcher.install()
+
+    @rpc(flags={"async"})
+    def _remove_result_batcher(self):
+        self._result_batcher.remove()
+        self._result_batcher = None
+
+    @rpc(flags={"async"})
     def _finish_point(self):
+        self._result_batcher.ensure_complete_and_push()
         if self.timestamp_sink:
             self.timestamp_sink.push(time.monotonic() - self._time_series_start)
         else:

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -55,6 +55,7 @@ from .result_channels import (
 )
 from .scan_generator import GENERATORS, INT_GENERATORS, ScanGenerator, ScanOptions
 from .scan_runner import (
+    ResultBatcher,
     ScanAxis,
     ScanSpec,
     describe_analyses,
@@ -322,6 +323,7 @@ class TopLevelRunner(HasEnvironment):
     ):
         self.fragment = fragment
         self.spec = spec
+        self.no_axes_mode = no_axes_mode
         self.max_rtio_underflow_retries = max_rtio_underflow_retries
         self.max_transitory_error_retries = max_transitory_error_retries
         self.skip_on_persistent_transitory_error = skip_on_persistent_transitory_error
@@ -339,12 +341,8 @@ class TopLevelRunner(HasEnvironment):
             dataset_prefix += "."
         self.dataset_prefix = dataset_prefix
 
-        # FIXME: We save these as individual booleans as enums crash the ARTIQ compiler.
-        self._continue_running = False
         self._is_time_series = False
-
         if not self.spec.axes:
-            self._continue_running = no_axes_mode != NoAxesMode.single
             if no_axes_mode == NoAxesMode.time_series:
                 self._is_time_series = True
                 param_schema = {
@@ -414,17 +412,28 @@ class TopLevelRunner(HasEnvironment):
         """Run the (possibly trivial) scan."""
         self._broadcast_metadata()
 
-        if not self.spec.axes and not self._is_time_series:
-            self._run_continuous()
-            return None, {c: s.get_last() for c, s in self._scan_result_sinks.items()}
-
-        if self._is_time_series:
-            self._timestamp_sink = AppendingDatasetSink(
-                self, self.dataset_prefix + "points.axis_0"
+        if not self.spec.axes or self._is_time_series:
+            timestamp_sink = None
+            if self._is_time_series:
+                timestamp_sink = AppendingDatasetSink(
+                    self, self.dataset_prefix + "points.axis_0"
+                )
+                self._coordinate_sinks = [timestamp_sink]
+            runner = _NoAxisRunner(
+                self,
+                fragment=self.fragment,
+                phase_dataset_key=self.dataset_prefix + "point_phase",
+                continue_running=self.no_axes_mode != NoAxesMode.single,
+                timestamp_sink=timestamp_sink,
+                max_rtio_underflow_retries=self.max_rtio_underflow_retries,
+                max_transitory_error_retries=self.max_transitory_error_retries,
             )
-            self._coordinate_sinks = [self._timestamp_sink]
-            self._time_series_start = time.monotonic()
-            self._run_continuous()
+            runner.run()
+            if not self._is_time_series:
+                self._set_completed()
+                return None, {
+                    c: s.get_last() for c, s in self._scan_result_sinks.items()
+                }
         else:
             runner = select_runner_class(self.fragment)(
                 self,
@@ -437,8 +446,7 @@ class TopLevelRunner(HasEnvironment):
                 for i in range(len(self.spec.axes))
             ]
             runner.run(self.fragment, self.spec, self._coordinate_sinks)
-            self._set_completed()
-
+        self._set_completed()
         return self._make_coordinate_dict(), self._make_value_dict()
 
     def _make_coordinate_dict(self):
@@ -479,48 +487,118 @@ class TopLevelRunner(HasEnvironment):
             for name, channel in self._analysis_results.items()
         }
 
-    def _run_continuous(self):
+    def _set_completed(self):
+        self.set_dataset(self.dataset_prefix + "completed", True, broadcast=True)
+
+    def _broadcast_metadata(self):
+        def push(name, value):
+            self.set_dataset(self.dataset_prefix + name, value, broadcast=True)
+
+        push(SCHEMA_REVISION_KEY, SCHEMA_REVISION)
+
+        source_prefix = self.get_dataset("system_id", default="rid")
+        push("source_id", f"{source_prefix}_{self.scheduler.rid}")
+
+        push("completed", False)
+
+        self._scan_desc = describe_scan(
+            self.spec, self.fragment, self._short_child_channel_names
+        )
+        self._scan_desc.update(
+            describe_analyses(self._analyses, self._annotation_context)
+        )
+        self._scan_desc["analysis_results"] = {
+            name: channel.describe() for name, channel in self._analysis_results.items()
+        }
+
+        for name, value in self._scan_desc.items():
+            # Flatten arrays/dictionaries to JSON strings for HDF5 compatibility.
+            ds_value = to_metadata_broadcast_type(value)
+            if ds_value is None:
+                push(name, dump_json(value))
+            else:
+                push(name, ds_value)
+
+    def create_applet(self, title: str, group: str = "ndscan"):
+        cmd = [
+            "${python}",
+            "-m ndscan.applet",
+            "--server=${server}",
+            "--port-notify=${port_notify}",
+            "--port-control=${port_control}",
+            f"--prefix={self.dataset_prefix}",
+        ]
+        self.ccb.issue("create_applet", title, " ".join(cmd), group=group)
+
+
+def _shorten_result_channel_names(full_names: Iterable[str]) -> dict[str, str]:
+    return shorten_to_unambiguous_suffixes(
+        full_names, lambda fqn, n: "/".join(fqn.split("/")[-n:])
+    )
+
+
+class _NoAxisRunner(HasEnvironment):
+    # TODO: Unify with _FragmentRunner.
+
+    def build(
+        self,
+        fragment: ExpFragment,
+        phase_dataset_key: str,
+        continue_running: bool,
+        timestamp_sink: AppendingDatasetSink | None,
+        max_rtio_underflow_retries: int,
+        max_transitory_error_retries: int,
+    ):
+        self.fragment = fragment
+        self.phase_dataset_key = phase_dataset_key
+        self.continue_running = continue_running
+        self.timestamp_sink = timestamp_sink
+        self.max_rtio_underflow_retries = max_rtio_underflow_retries
+        self.max_transitory_error_retries = max_transitory_error_retries
+        self.setattr_device("core")
+        self.setattr_device("scheduler")
+
+    def run(self):
+        if self.timestamp_sink is not None:
+            self._time_series_start = time.monotonic()
+
         self._point_phase = False
-        # TODO: Unify with _FragmentRunner.
         self.num_current_transitory_errors = 0
         self.num_current_underflows = 0
-        try:
-            while True:
-                # After every pause(), pull in dataset changes (immediately as well to
-                # catch changes between the time the experiment is prepared and when it
-                # is run, to keep the semantics uniform).
-                self.fragment.recompute_param_defaults()
-                try:
-                    self.fragment.host_setup()
-                    if is_kernel(self.fragment.run_once):
-                        done = self._run_continuous_kernel()
-                        self.core.comm.close()
-                        if done:
-                            break
-                    else:
-                        if self._continuous_loop():
-                            break
-                finally:
-                    self.fragment.host_cleanup()
-                self.scheduler.pause()
-        finally:
-            self._set_completed()
+
+        while True:
+            # After every pause(), pull in dataset changes (immediately as well to
+            # catch changes between the time the experiment is prepared and when it
+            # is run, to keep the semantics uniform).
+            self.fragment.recompute_param_defaults()
+            try:
+                self.fragment.host_setup()
+                if is_kernel(self.fragment.run_once):
+                    done = self._run_kernel()
+                    self.core.comm.close()
+                    if done:
+                        break
+                else:
+                    if self._run_loop():
+                        break
+            finally:
+                self.fragment.host_cleanup()
+            self.scheduler.pause()
 
     @kernel
-    def _run_continuous_kernel(self):
+    def _run_kernel(self):
         self.core.reset()
-        return self._continuous_loop()
+        return self._run_loop()
 
     @portable
-    def _continuous_loop(self):
-        # TODO: Unify with _FragmentRunner.
+    def _run_loop(self):
         try:
             while not self.scheduler.check_pause():
                 try:
                     self.fragment.device_setup()
                     self.fragment.run_once()
-                    self._finish_continuous_point()
-                    if not self._continue_running:
+                    self._finish_point()
+                    if not self.continue_running:
                         return True
 
                     # One point is now finished, so reset transitory error counters for
@@ -574,63 +652,12 @@ class TopLevelRunner(HasEnvironment):
         return True
 
     @rpc(flags={"async"})
-    def _finish_continuous_point(self):
-        if self._is_time_series:
-            self._timestamp_sink.push(time.monotonic() - self._time_series_start)
+    def _finish_point(self):
+        if self.timestamp_sink:
+            self.timestamp_sink.push(time.monotonic() - self._time_series_start)
         else:
             self._point_phase = not self._point_phase
-            self.set_dataset(
-                self.dataset_prefix + "point_phase", self._point_phase, broadcast=True
-            )
-
-    def _set_completed(self):
-        self.set_dataset(self.dataset_prefix + "completed", True, broadcast=True)
-
-    def _broadcast_metadata(self):
-        def push(name, value):
-            self.set_dataset(self.dataset_prefix + name, value, broadcast=True)
-
-        push(SCHEMA_REVISION_KEY, SCHEMA_REVISION)
-
-        source_prefix = self.get_dataset("system_id", default="rid")
-        push("source_id", f"{source_prefix}_{self.scheduler.rid}")
-
-        push("completed", False)
-
-        self._scan_desc = describe_scan(
-            self.spec, self.fragment, self._short_child_channel_names
-        )
-        self._scan_desc.update(
-            describe_analyses(self._analyses, self._annotation_context)
-        )
-        self._scan_desc["analysis_results"] = {
-            name: channel.describe() for name, channel in self._analysis_results.items()
-        }
-
-        for name, value in self._scan_desc.items():
-            # Flatten arrays/dictionaries to JSON strings for HDF5 compatibility.
-            ds_value = to_metadata_broadcast_type(value)
-            if ds_value is None:
-                push(name, dump_json(value))
-            else:
-                push(name, ds_value)
-
-    def create_applet(self, title: str, group: str = "ndscan"):
-        cmd = [
-            "${python}",
-            "-m ndscan.applet",
-            "--server=${server}",
-            "--port-notify=${port_notify}",
-            "--port-control=${port_control}",
-            f"--prefix={self.dataset_prefix}",
-        ]
-        self.ccb.issue("create_applet", title, " ".join(cmd), group=group)
-
-
-def _shorten_result_channel_names(full_names: Iterable[str]) -> dict[str, str]:
-    return shorten_to_unambiguous_suffixes(
-        full_names, lambda fqn, n: "/".join(fqn.split("/")[-n:])
-    )
+            self.set_dataset(self.phase_dataset_key, self._point_phase, broadcast=True)
 
 
 def make_fragment_scan_exp(
@@ -689,7 +716,7 @@ class _FragmentRunner(HasEnvironment):
         self.num_transitory_errors_caught = 0
 
     def run(self) -> bool:
-        """Execute device_setup()/run_once(), retrying if nececssary.
+        """Execute device_setup()/run_once(), retrying if necessary.
 
         :return: ``True`` if execution completed, ``False`` if it should be attempted
             again (RestartKernelTransitoryError).

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -641,8 +641,7 @@ class Fragment(HasEnvironment):
             fragment.
         """
         assert self._building, (
-            "Can only call detach subfragments while parent still"
-            + "in build_fragment()"
+            "Can only call detach subfragments while parent still in build_fragment()"
         )
         assert fragment in self._subfragments, (
             "Can only detach subfragments directly from their parent fragment"

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -10,6 +10,7 @@ from artiq.language import HasEnvironment, kernel, portable, rpc
 from .utils import dump_json
 
 __all__ = [
+    "ResultLifecycleError",
     "SingleUseSink",
     "LastValueSink",
     "ArraySink",
@@ -23,23 +24,47 @@ __all__ = [
 ]
 
 
+class ResultLifecycleError(RuntimeError):
+    """Raised if a result channel was not pushed to, or was pushed to more than once per
+    point.
+    """
+    pass
+
+
 class ResultSink:
     """ """
 
     def push(self, value: Any) -> None:
         """Record a new value.
 
-        This should never fail; neither in the sense of raising an exception, nor (for
-        sinks that record a series of values) in the sense of failing to record the
-        presence of a value, as code consuming results relies on one ``push()`` each to
-        a set of result channels and subsequently sinks representing a single multi-
-        dimensional data point.
+        Due to limited availability of generics or metaprogramming in ARTIQ Python,
+        result handling is implemented as a disaggregated set of channels, where each
+        channel (and in turn sink) is pushed to once per logical point. In other words,
+        results are stored in "struct of arrays" rather than "array of structs" form,
+        where the arrays are built up by repeated ``push()`` calls.
+
+        The ndscan scan runners will ensure that each channel is pushed to exactly once
+        per points; if this invariant is violated, a :class:`ResultLifecycleError` is
+        raised, and _none_ of the results are forwarded to the top-level sinks. This
+        ensures that dataset arrays remain rectangular with a clear point index to
+        element mapping, and points are retryable.
+
+        Pushing to user-provided top-level sinks usually should not fail. If pushing is
+        fallible, ndscan does not provide any help with ensuring that the
+        one-push()-per-point invariant is preserved. That is, such errors should be
+        considered to be unrecoverable, unless the user code takes steps to avoid a
+        situation where sinks on other channels pushed to before the failure hold data
+        for a point but others do not.
         """
         raise NotImplementedError
 
 
 class SingleUseSink(ResultSink):
-    """Sink that allows only one value to be pushed (before being cleared)."""
+    """Sink that allows only one value to be pushed (before being cleared).
+
+    This is used by ndscan internally to ensure each channel is pushed to exactly once
+    per point.
+    """
 
     def __init__(self):
         self._is_set: bool = False
@@ -47,7 +72,7 @@ class SingleUseSink(ResultSink):
 
     def push(self, value: Any) -> None:
         if self._is_set:
-            raise RuntimeError("Result channel already pushed to")
+            raise ResultLifecycleError("Result channel already pushed to")
         self._value = value
         self._is_set = True
 
@@ -56,7 +81,7 @@ class SingleUseSink(ResultSink):
 
     def get(self) -> Any:
         if not self._is_set:
-            raise ValueError("No value pushed to sink")
+            raise ResultLifecycleError("No value pushed to sink")
         return self._value
 
     def get_last(self) -> Any:

--- a/ndscan/experiment/result_channels.py
+++ b/ndscan/experiment/result_channels.py
@@ -28,6 +28,7 @@ class ResultLifecycleError(RuntimeError):
     """Raised if a result channel was not pushed to, or was pushed to more than once per
     point.
     """
+
     pass
 
 
@@ -66,13 +67,21 @@ class SingleUseSink(ResultSink):
     per point.
     """
 
-    def __init__(self):
+    def __init__(self, channel_path: str):
+        """
+        :param channel_path: Name of the associated result channel, to streamline error
+            message generation. (Strictly speaking, this is a layering violation, and
+            could be handled by re-raising in ResultChannel.push() instead.)
+        """
+        self._channel_path = channel_path
         self._is_set: bool = False
         self._value: Any = None
 
     def push(self, value: Any) -> None:
         if self._is_set:
-            raise ResultLifecycleError("Result channel already pushed to")
+            raise ResultLifecycleError(
+                f"Already pushed to result channel '{self._channel_path}'"
+            )
         self._value = value
         self._is_set = True
 
@@ -81,7 +90,9 @@ class SingleUseSink(ResultSink):
 
     def get(self) -> Any:
         if not self._is_set:
-            raise ResultLifecycleError("No value pushed to sink")
+            raise ResultLifecycleError(
+                f"No value pushed to result channel '{self._channel_path}"
+            )
         return self._value
 
     def get_last(self) -> Any:

--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -179,7 +179,7 @@ class ResultBatcher:
             if channel.sink is None:
                 continue
             self._orig_sinks[channel] = channel.sink
-            channel.sink = SingleUseSink()
+            channel.sink = SingleUseSink(channel.path)
 
     def discard_current(self) -> None:
         """Discard any results that may have been pushed already (e.g. if a point was

--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -19,7 +19,12 @@ from artiq.language import HasEnvironment, host_only, kernel, kernel_from_string
 from .default_analysis import AnnotationContext, DefaultAnalysis
 from .fragment import ExpFragment, RestartKernelTransitoryError, TransitoryError
 from .parameters import ParamStore
-from .result_channels import ResultChannel, ResultSink, SingleUseSink
+from .result_channels import (
+    ResultChannel,
+    ResultLifecycleError,
+    ResultSink,
+    SingleUseSink,
+)
 from .scan_generator import ScanGenerator, ScanOptions, generate_points
 from .utils import is_kernel
 
@@ -193,7 +198,7 @@ class ResultBatcher:
         # First check whether we have all the values.
         for channel in self._orig_sinks.keys():
             if not channel.sink.is_set():
-                raise ValueError(
+                raise ResultLifecycleError(
                     f"Missing value for result channel '{channel}' "
                     + "(push() not called for current point)"
                 )

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -256,3 +256,15 @@ class ReadParamDefault(ExpFragment):
 
     def run_once(self) -> None:
         self.value.push(self.foo.get())
+
+
+class DoublePushFragment(ExpFragment):
+    """Calls push() twice on a result channel, to check logic for detecting this."""
+
+    def build_fragment(self):
+        self.setattr_param("value", FloatParam, "Value to push", default=0.0)
+        self.setattr_result("result", FloatChannel)
+
+    def run_once(self):
+        self.result.push(self.value.get())
+        self.result.push(self.value.get())

--- a/test/test_experiment_entrypoint.py
+++ b/test/test_experiment_entrypoint.py
@@ -336,6 +336,12 @@ class FragmentScanExpCase(HasEnvironmentCase):
 
         self.assertEqual(self.dataset_db.data["ndscan.rid_0.point.value"][1], 2)
 
+    def test_double_push_trivial(self):
+        with self.assertRaises(ResultLifecycleError):
+            exp = self.create(ScanDoublePushExp)
+            exp.prepare()
+            exp.run()
+
     def test_double_push_1d(self):
         with self.assertRaises(ResultLifecycleError):
             self._test_run_1d(ScanDoublePushExp, "fixtures.DoublePushFragment", [])

--- a/test/test_experiment_entrypoint.py
+++ b/test/test_experiment_entrypoint.py
@@ -7,6 +7,7 @@ import json
 from fixtures import (
     AddOneAggregate,
     AddOneFragment,
+    DoublePushFragment,
     MultiPointTransitoryErrorFragment,
     MultiReboundAddOneFragment,
     ReadParamDefault,
@@ -25,9 +26,10 @@ from ndscan.experiment.utils import is_kernel
 from ndscan.utils import PARAMS_ARG_KEY, SCHEMA_REVISION, SCHEMA_REVISION_KEY
 
 ScanAddOneExp = make_fragment_scan_exp(AddOneFragment)
+ScanDoublePushExp = make_fragment_scan_exp(DoublePushFragment)
+ScanReadParamDefaultExp = make_fragment_scan_exp(ReadParamDefault)
 ScanReboundAddOneExp = make_fragment_scan_exp(ReboundAddOneFragment)
 ScanTwoAnalysisAggregateExp = make_fragment_scan_exp(TwoAnalysisAggregate)
-ScanReadParamDefaultExp = make_fragment_scan_exp(ReadParamDefault)
 
 
 class TestAggregateExpFragment(HasEnvironmentCase):
@@ -333,6 +335,10 @@ class FragmentScanExpCase(HasEnvironmentCase):
         exp.run()
 
         self.assertEqual(self.dataset_db.data["ndscan.rid_0.point.value"][1], 2)
+
+    def test_double_push_1d(self):
+        with self.assertRaises(ResultLifecycleError):
+            self._test_run_1d(ScanDoublePushExp, "fixtures.DoublePushFragment", [])
 
 
 class RunOnceCase(HasEnvironmentCase):

--- a/test/test_plots_schema_handling.py
+++ b/test/test_plots_schema_handling.py
@@ -13,10 +13,15 @@ class NestedFragment(Fragment):
             "h", FloatChannel, display_hints={"share_axis_with": self.g.path}
         )
 
+    def run_once(self):
+        self.g.push(0.0)
+        self.h.push(0.0)
+
 
 class TestFragment(ExpFragment):
     def build_fragment(self):
-        # Manually specify root path to exercise different orders in .
+        # Manually specify share target path to exercise different orders in
+        # grouping code.
         self.setattr_result("a", FloatChannel, display_hints={"share_axis_with": "d"})
         self.setattr_result("b", IntChannel, display_hints={"priority": 1})
         self.setattr_result("c", OpaqueChannel)
@@ -37,6 +42,19 @@ class TestFragment(ExpFragment):
         self.setattr_fragment("n2", NestedFragment)
         self.setattr_fragment("n3", NestedFragment)
         self.n3.g.display_hints["share_axis_with"] = self.n2.g.path
+
+    def run_once(self):
+        self.a.push(0.0)
+        self.b.push(0)
+        self.c.push(0)
+        self.d.push(0.0)
+        self.e.push(0.0)
+        self.f.push(0.0)
+        self.a_err.push(0.0)
+        self.n0.run_once()
+        self.n1.run_once()
+        self.n2.run_once()
+        self.n3.run_once()
 
 
 TestExp = make_fragment_scan_exp(TestFragment)


### PR DESCRIPTION
This creates consistency between regular scans (which already caught this after the introduction of `ResultBatcher`) and single/time-series mode.

- **fragment: Remove unnecessary line break [nfc]**
- **experiment.result_channels: Add specific ResultLifecycleError error type, update ResultSink docstring**
- **epxeriment.result_channels: Add channel name to result lifecycle error messages**
- **test: Add test for double push error in scan**
- **experiment: Factor no-axis scan code out of TopLevelRunner [nfc]**
- **experiment: Also catch missing/duplicate points in no-axis (single/time series) mode**
