### PR TITLE
plots: Fix crosshairs for non-float parameter scans

### DIFF
--- a/ndscan/plots/cursor.py
+++ b/ndscan/plots/cursor.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pyqtgraph
 
 from .._qt import QtCore, QtGui, QtWidgets
@@ -58,15 +60,19 @@ class CrosshairLabel:
         raise NotImplementedError
 
     def set_value(self, value: float, limits: tuple[float, float]):
-        text = format_label_value(
-            value, self.data_to_display_scale, limits, self.unit_suffix
-        )
+        text = self._format_label_value(value, limits)
+
         for label in self.text_items:
             label.setText(text)
 
     def set_visible(self, visible: bool):
         for label in self.text_items:
             label.setVisible(visible)
+
+    def _format_label_value(self, value: float, limits: tuple[float, float]) -> str:
+        return format_label_value(
+            value, self.data_to_display_scale, limits, self.unit_suffix
+        )
 
 
 class CrosshairAxisLabel(CrosshairLabel):
@@ -79,10 +85,12 @@ class CrosshairAxisLabel(CrosshairLabel):
         data_to_display_scale: float = 1.0,
         color: str = SERIES_COLORS[0],
         is_x: bool = False,
+        param_schema: dict[str, Any] = {},
     ):
         super().__init__(view_box, unit_suffix, data_to_display_scale, color)
         self.is_x = is_x
         self.last_value = None
+        self.param_schema = param_schema
 
     def update_coords(self, data_coords):
         x_range, y_range = self.view_box.state["viewRange"]
@@ -90,6 +98,15 @@ class CrosshairAxisLabel(CrosshairLabel):
         limits = tuple(x_range if self.is_x else y_range)
         self.set_value(coord, limits)
         self.last_value = coord
+
+    def _format_label_value(self, value: float, limits: tuple[float, float]) -> str:
+        return format_label_value(
+            value,
+            self.data_to_display_scale,
+            limits,
+            self.unit_suffix,
+            self.param_schema,
+        )
 
 
 class LabeledCrosshairCursor(QtCore.QObject):

--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -25,6 +25,7 @@ from .utils import (
     find_neighbour_index,
     format_param_identity,
     get_axis_scaling_info,
+    parse_coord_param_value,
     setup_axis_item,
     slice_data_along_axis,
 )
@@ -496,9 +497,22 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
         if not self.plot:
             logger.warning("Plot not initialised yet, ignoring set dataset request")
             return
-        self.model.context.set_dataset(
-            dataset, self.crosshair.labels[axis_idx].last_value
-        )
+
+        coordinate = self.crosshair.labels[axis_idx].last_value
+
+        try:
+            value = parse_coord_param_value(
+                coordinate,
+                self.model.axes[axis_idx]["param"],
+            )
+            self.model.context.set_dataset(dataset, value)
+        except ValueError:
+            logger.warning(
+                "Crosshair value %s could not be categorised for dataset '%s'",
+                self.crosshair.labels[axis_idx].last_value,
+                dataset,
+            )
+            return
 
     def _point_clicked(self, pos: QtCore.QPointF):
         """Callback for when `self.plot` is clicked.

--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -397,10 +397,16 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
         y_scaling_info = get_axis_scaling_info(self.y_schema["param"]["spec"])
 
         x_label = CrosshairAxisLabel(
-            self.plot_item.getViewBox(), *x_scaling_info, is_x=True
+            self.plot_item.getViewBox(),
+            *x_scaling_info,
+            is_x=True,
+            param_schema=self.x_schema["param"],
         )
         y_label = CrosshairAxisLabel(
-            self.plot_item.getViewBox(), *y_scaling_info, is_x=False
+            self.plot_item.getViewBox(),
+            *y_scaling_info,
+            is_x=False,
+            param_schema=self.y_schema["param"],
         )
 
         self.crosshair = LabeledCrosshairCursor(

--- a/ndscan/plots/utils.py
+++ b/ndscan/plots/utils.py
@@ -500,9 +500,6 @@ def format_label_value(
     try:
         parsed_value = parse_coord_param_value(value, param_schema)
     except ValueError:
-        parsed_value = None
-
-    if parsed_value is None:
         return "?"
 
     match axis_type:

--- a/ndscan/plots/utils.py
+++ b/ndscan/plots/utils.py
@@ -488,23 +488,78 @@ def format_label_value(
     data_to_display_scale: float,
     limits: tuple[float, float],
     unit_suffix: str,
+    param_schema: dict[str, Any] = {},
 ) -> str:
     """Format axis position with sensible precision for display in a label.
 
     We do not have any metadata for the number of digits to show, so we guess from the
     range of displayed data (if available).
     """
-    # Base case: we want to resolve at least milli-units on the data's scale.
-    span = data_to_display_scale
-    if limits[1] > limits[0]:
-        # Preferred case: we want to resolve >1000 points in the displayed range.
-        span *= limits[1] - limits[0]
-    elif np.abs(value) > 0:
-        # Fallback case: we want to resolve >3 significant figures of the value.
-        span *= value
-    smallest_digit = np.floor(np.log10(span)) - 3
-    precision = int(-smallest_digit) if smallest_digit < 0 else 0
+    axis_type = param_schema.get("type", "float")
 
-    return "{0:.{n}f}{1}".format(
-        value * data_to_display_scale, unit_suffix, n=precision
-    )
+    try:
+        parsed_value = parse_coord_param_value(value, param_schema)
+    except ValueError:
+        parsed_value = None
+
+    if parsed_value is None:
+        return "?"
+
+    match axis_type:
+        case "bool" | "enum":
+            return str(parsed_value)
+        case "int" | "float":
+            # Base case: we want to resolve at least milli-units on the data's scale.
+            span = data_to_display_scale
+            if limits[1] > limits[0]:
+                # Preferred case: we want to resolve >1000 points in the displayed range.
+                span *= limits[1] - limits[0]
+            elif np.abs(parsed_value) > 0:
+                # Fallback case: we want to resolve >3 significant figures of the value.
+                span *= parsed_value
+            smallest_digit = np.floor(np.log10(span)) - 3
+
+            if axis_type == "int":
+                smallest_digit = max(smallest_digit, 0)
+
+            precision = int(-smallest_digit) if smallest_digit < 0 else 0
+
+            return "{0:.{n}f}{1}".format(
+                parsed_value * data_to_display_scale, unit_suffix, n=precision
+            )
+        case _:
+            raise ValueError(f"Unknown axis type '{axis_type}'")
+
+
+def parse_coord_param_value(coord: float, param_schema: dict[str, Any]) -> Any:
+    """Parse a coordinate as a parameter specified by its schema.
+
+    Raises `ValueError` for categorical parameters if the coordinate is out of range.
+
+    :param coord: The coordinate value to parse.
+    :param param_schema: The parameter schema for the axis.
+    :return: The parsed parameter value.
+    """
+    axis_type = param_schema.get("type", "float")
+
+    match axis_type:
+        case "bool":
+            if round(coord) not in [0, 1]:
+                raise ValueError(
+                    f"Coordinate {coord} categorisation as bool undefined."
+                )
+            return round(coord) == 1
+        case "enum":
+            members = param_schema.get("spec", {}).get("members", {}).keys()
+            try:
+                return list(members)[round(coord)]
+            except IndexError:
+                raise ValueError(
+                    f"Coordinate {coord} categorisation as given enum undefined."
+                )
+        case "int":
+            return int(round(coord))
+        case "float":
+            return float(coord)
+        case _:
+            raise ValueError(f"Unknown axis type '{axis_type}'")

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -379,6 +379,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
                 self.x_unit_suffix,
                 self.x_data_to_display_scale,
                 is_x=True,
+                param_schema=self.x_schema["param"],
             )
             crosshair_labels = [x_label] + crosshair_labels
             crosshair = LabeledCrosshairCursor(self, pane, crosshair_labels)

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -31,6 +31,7 @@ from .utils import (
     group_axes_into_panes,
     group_channels_into_axes,
     hide_series_from_groups,
+    parse_coord_param_value,
     setup_axis_item,
 )
 
@@ -563,10 +564,19 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
         if not self.crosshairs:
             logger.warning("Plot not initialised yet, ignoring set dataset request")
             return
+
         # The x crosshair is always the first item (see `_initialise_series()`).
-        self.model.context.set_dataset(
-            dataset_key, self.crosshairs[pane_idx].labels[0].last_value
-        )
+        coordinate = self.crosshairs[pane_idx].labels[0].last_value
+
+        try:
+            value = parse_coord_param_value(coordinate, self.x_schema["param"])
+            self.model.context.set_dataset(dataset_key, value)
+        except ValueError:
+            logger.warning(
+                "Crosshair x value %s could not be categorised for dataset '%s'",
+                coordinate,
+                dataset_key,
+            )
 
     def _point_clicked(self, scatter_plot_item, spot_items: np.ndarray, ev):
         if len(spot_items) == 0:


### PR DESCRIPTION
The crosshair labels always display the cursor position as a float, which is not particularly meaningful for bool, enum, or even int scans. Furthermore, "set dataset ... from crosshairs" then always write a float, which is also not ideal.

I've currently set it so that for categorical data, if the closest integer value is outside the label indices, the label shows a "?" and does nothing upon "set dataset..."