### PR TITLE
plots.model.subscan: Properly resolve subscan data channels by path

### DIFF
--- a/ndscan/plots/model/subscan.py
+++ b/ndscan/plots/model/subscan.py
@@ -42,7 +42,7 @@ class SubscanRoot(Root):
         self._schema_str = schema_str
         self._schema = json.loads(schema_str)
 
-        self._model = SubscanModel(self._schema, self._parent, self.name + "_")
+        self._model = SubscanModel(self._schema, self._parent, self._schema_key)
         self.model_changed.emit(self._model)
 
     def get_model(self) -> Model | None:
@@ -60,13 +60,32 @@ class SubscanModel(ScanModel):
     """
 
     def __init__(
-        self, schema: dict[str, Any], parent: SinglePointModel, result_prefix: str
+        self, schema: dict[str, Any], parent: SinglePointModel, spec_channel_name: str
     ):
         super().__init__(schema["axes"], parent.schema_revision, parent.context)
-
         self._channel_schemata = schema["channels"]
 
-        self._result_prefix = result_prefix
+        # Resolve the result channels holding the flattened subscan data by path. An
+        # unfortunate consequence of the shortest-unambiguous-suffix path -> channel
+        # name shortening occurring independently per channel is that the data channel
+        # names cannot be derived from the spec channel name, as the data channel names
+        # may be unique even if "spec" isn't.
+        parent_schemata = parent.get_channel_schemata()
+        names_by_path = {s["path"]: n for n, s in parent_schemata.items()}
+        path_prefix = strip_suffix(parent_schemata[spec_channel_name]["path"], "spec")
+        self._data_channel_names = {}
+        for name in [f"axis_{i}" for i in range(len(self.axes))] + [
+            "channel_" + c for c in self._channel_schemata.keys()
+        ]:
+            path = path_prefix + name
+            parent_name = names_by_path.get(path)
+            if parent_name is None:
+                raise ValueError(
+                    f"Did not find channel with path '{path}' among parent scan "
+                    f"channels while resolving subscan '{spec_channel_name}"
+                )
+            self._data_channel_names[name] = parent_name
+
         self._point_data = {}
         self._parent = parent
         self._parent.point_changed.connect(self._update)
@@ -96,10 +115,8 @@ class SubscanModel(ScanModel):
             logger.debug("Ignoring update")
             return
 
-        for name in [f"axis_{i}" for i in range(len(self.axes))] + [
-            "channel_" + c for c in self._channel_schemata.keys()
-        ]:
-            self._point_data[name] = parent_data[self._result_prefix + name]
+        for name, parent_name in self._data_channel_names.items():
+            self._point_data[name] = parent_data[parent_name]
         self.points_rewritten.emit(self._point_data)
 
         for r, c in self._analysis_result_mappings:

--- a/test/test_plots_model_subscan.py
+++ b/test/test_plots_model_subscan.py
@@ -1,0 +1,150 @@
+"""
+Tests for extracting subscan models from single points (ndscan.plots.model.subscan),
+run against actual experiment output to cover the channel naming contract between the
+experiment and applet sides.
+"""
+
+import json
+from typing import Any
+
+from mock_environment import HasEnvironmentCase
+
+from ndscan.experiment import *
+from ndscan.plots.model import Context, SinglePointModel
+from ndscan.plots.model.subscan import create_subscan_roots
+from ndscan.utils import SCHEMA_REVISION_KEY
+
+#
+# Set up two fragments with disjoint result channel names, and subscans scanning them.
+#
+
+
+class LeafAFragment(ExpFragment):
+    def build_fragment(self):
+        self.setattr_param("value", FloatParam, "Value", default=0.0)
+        self.setattr_result("result", FloatChannel)
+
+    def run_once(self):
+        self.result.push(self.value.get() + 1)
+
+
+class LeafBFragment(ExpFragment):
+    def build_fragment(self):
+        self.setattr_param("offset", FloatParam, "Offset", default=0.0)
+        self.setattr_result("total", FloatChannel)
+
+    def run_once(self):
+        self.total.push(self.offset.get() + 10)
+
+
+class SubscanA(SubscanExpFragment):
+    def build_fragment(self):
+        self.setattr_fragment("frag", LeafAFragment)
+        super().build_fragment(self, self.frag, [(self.frag, "value")])
+        self.configure([(self.frag.value, LinearGenerator(0.0, 2.0, 3, False))])
+
+
+class SubscanB(SubscanExpFragment):
+    def build_fragment(self):
+        self.setattr_fragment("frag", LeafBFragment)
+        super().build_fragment(self, self.frag, [(self.frag, "offset")])
+        self.configure([(self.frag.offset, LinearGenerator(0.0, 4.0, 3, False))])
+
+
+# # #
+
+
+class TwoSubscansFragment(ExpFragment):
+    """Combines two subscans with disjoint result channel names (but same scan `spec`
+    channel name).
+    """
+
+    def build_fragment(self):
+        self.setattr_fragment("scan_a", SubscanA)
+        self.setattr_fragment("scan_b", SubscanB)
+
+    def run_once(self):
+        self.scan_a.run_once()
+        self.scan_b.run_once()
+
+
+TwoSubscansExp = make_fragment_scan_exp(TwoSubscansFragment)
+
+
+class LegacySubscanFragment(ExpFragment):
+    """Straightforward, single legacy subscan as a baseline.
+
+    This also differs from the SubscanExpFragments in having a non-empty channel name
+    prefix (`scan_spec` rather than `_spec`, etc.).
+    """
+
+    def build_fragment(self):
+        self.setattr_fragment("child", LeafAFragment)
+        setattr_subscan(self, "scan", self.child, [(self.child, "value")])
+
+    def run_once(self):
+        self.scan.run([(self.child.value, LinearGenerator(0.0, 2.0, 3, False))])
+
+
+LegacySubscanExp = make_fragment_scan_exp(LegacySubscanFragment)
+
+
+class DatasetSinglePointModel(SinglePointModel):
+    """Exposes the datasets produced by a no-axes scan in the same way as the `hdf5` or
+    `subscriber` single-point models do, but without jumping through the hoops of
+    setting up that machinery.
+    """
+
+    def __init__(self, dataset_db, prefix: str, context: Context):
+        super().__init__(dataset_db.get(prefix + SCHEMA_REVISION_KEY), context)
+        self._channel_schemata = json.loads(dataset_db.get(prefix + "channels"))
+        self._point = {
+            name: dataset_db.get(prefix + "point." + name)
+            for name in self._channel_schemata.keys()
+        }
+
+    def get_channel_schemata(self) -> dict[str, Any]:
+        return self._channel_schemata
+
+    def get_point(self) -> dict[str, Any] | None:
+        return self._point
+
+
+class SubscanModelCase(HasEnvironmentCase):
+    def _run_and_get_model(self, klass):
+        exp = self.create(klass)
+        exp.prepare()
+        exp.run()
+        return DatasetSinglePointModel(self.dataset_db, "ndscan.rid_0.", Context())
+
+    def test_resolve_inconsistently_shortened_channel_names(self):
+        model = self._run_and_get_model(TwoSubscansExp)
+
+        # Make sure this exercises the interesting case, where globally unique leaf
+        # names cause the channels holding the subscan data to be shortened such that
+        # they do not retain the name of their spec channel as a prefix.
+        schemata = model.get_channel_schemata()
+        self.assertIn("scan_a__spec", schemata)
+        self.assertIn("_channel_result", schemata)
+        self.assertIn("_channel_total", schemata)
+
+        roots = create_subscan_roots(model)
+        self.assertEqual(sorted(roots.keys()), ["scan_a_", "scan_b_"])
+
+        data_a = roots["scan_a_"].get_model().get_point_data()
+        self.assertEqual(list(data_a["axis_0"]), [0.0, 1.0, 2.0])
+        self.assertEqual(list(data_a["channel_result"]), [1.0, 2.0, 3.0])
+
+        data_b = roots["scan_b_"].get_model().get_point_data()
+        self.assertEqual(list(data_b["axis_0"]), [0.0, 2.0, 4.0])
+        self.assertEqual(list(data_b["channel_total"]), [10.0, 12.0, 14.0])
+
+    def test_resolve_legacy_subscan_channel_names(self):
+        model = self._run_and_get_model(LegacySubscanExp)
+
+        roots = create_subscan_roots(model)
+        self.assertEqual(list(roots.keys()), ["scan"])
+
+        data = roots["scan"].get_model().get_point_data()
+        self.assertEqual(list(data["axis_0"]), [0.0, 1.0, 2.0])
+        self.assertEqual(list(data["channel_result"]), [1.0, 2.0, 3.0])


### PR DESCRIPTION
This edge case affected experiments with multiple subscans.
