### PR TITLE
Fix phantom cursor labels at negative coordinates for categorical scans

### DIFF
--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -25,6 +25,7 @@ from .utils import (
     find_neighbour_index,
     format_param_identity,
     get_axis_scaling_info,
+    get_param_categories,
     parse_coord_param_value,
     setup_axis_item,
     slice_data_along_axis,
@@ -631,3 +632,16 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
                 fixed_axis_source == fixed_axis_coord,
             )
         )
+
+    def _set_view_box_limits(self, view_box):
+        x_param_categories = get_param_categories(self.x_schema["param"])
+        if x_param_categories is not None:
+            x_min = -0.5
+            x_max = len(x_param_categories) - 0.5
+            view_box.setLimits(xMin=x_min, xMax=x_max, minXRange=1.05)
+
+        y_param_categories = get_param_categories(self.y_schema["param"])
+        if y_param_categories is not None:
+            y_min = -0.5
+            y_max = len(y_param_categories) - 0.5
+            view_box.setLimits(yMin=y_min, yMax=y_max, minYRange=1.05)

--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -416,6 +416,7 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
         )
 
         add_source_id_label(self.plot_item.getViewBox(), self.model.context)
+        self._set_view_box_limits(self.plot_item.getViewBox())
 
         self.subscan_roots = create_subscan_roots(self.selected_point_model)
         self.slice_roots = create_slice_roots(self.model, self.selected_point_model)
@@ -634,14 +635,22 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
         )
 
     def _set_view_box_limits(self, view_box):
+        kwargs = {}
+
         x_param_categories = get_param_categories(self.x_schema["param"])
         if x_param_categories is not None:
-            x_min = -0.5
-            x_max = len(x_param_categories) - 0.5
-            view_box.setLimits(xMin=x_min, xMax=x_max, minXRange=1.05)
+            kwargs |= {
+                "xMin": -0.5,
+                "xMax": len(x_param_categories) - 0.5,
+                "minXRange": 1.05,
+            }
 
         y_param_categories = get_param_categories(self.y_schema["param"])
         if y_param_categories is not None:
-            y_min = -0.5
-            y_max = len(y_param_categories) - 0.5
-            view_box.setLimits(yMin=y_min, yMax=y_max, minYRange=1.05)
+            kwargs |= {
+                "yMin": -0.5,
+                "yMax": len(y_param_categories) - 0.5,
+                "minYRange": 1.05,
+            }
+
+        view_box.setLimits(**kwargs)

--- a/ndscan/plots/utils.py
+++ b/ndscan/plots/utils.py
@@ -547,7 +547,7 @@ def parse_coord_param_value(coord: float, param_schema: dict[str, Any]) -> Any:
                 )
             return round(coord) == 1
         case "enum":
-            members = list(param_schema.get("spec", {}).get("members", {}).keys())
+            members = list(param_schema.get("spec", {}).get("members", {}).values())
             enum_idx = round(coord)
             if not 0 <= enum_idx < len(list(members)):
                 raise ValueError(

--- a/ndscan/plots/utils.py
+++ b/ndscan/plots/utils.py
@@ -547,13 +547,13 @@ def parse_coord_param_value(coord: float, param_schema: dict[str, Any]) -> Any:
                 )
             return round(coord) == 1
         case "enum":
-            members = param_schema.get("spec", {}).get("members", {}).keys()
-            try:
-                return list(members)[round(coord)]
-            except IndexError:
+            members = list(param_schema.get("spec", {}).get("members", {}).keys())
+            enum_idx = round(coord)
+            if not 0 <= enum_idx < len(list(members)):
                 raise ValueError(
                     f"Coordinate {coord} categorisation as given enum undefined."
                 )
+            return members[enum_idx]
         case "int":
             return int(round(coord))
         case "float":

--- a/ndscan/plots/utils.py
+++ b/ndscan/plots/utils.py
@@ -502,30 +502,29 @@ def format_label_value(
     except ValueError:
         return "?"
 
-    match axis_type:
-        case "bool" | "enum":
-            return str(parsed_value)
-        case "int" | "float":
-            # Base case: we want to resolve at least milli-units on the data's scale.
-            span = data_to_display_scale
-            if limits[1] > limits[0]:
-                # Preferred case: we want to resolve >1000 points in the displayed range.
-                span *= limits[1] - limits[0]
-            elif np.abs(parsed_value) > 0:
-                # Fallback case: we want to resolve >3 significant figures of the value.
-                span *= parsed_value
-            smallest_digit = np.floor(np.log10(span)) - 3
+    if axis_type in ["bool", "enum"]:
+        return str(parsed_value)
+    elif axis_type in ["int", "float"]:
+        # Base case: we want to resolve at least milli-units on the data's scale.
+        span = data_to_display_scale
+        if limits[1] > limits[0]:
+            # Preferred case: we want to resolve >1000 points in the displayed range.
+            span *= limits[1] - limits[0]
+        elif np.abs(parsed_value) > 0:
+            # Fallback case: we want to resolve >3 significant figures of the value.
+            span *= parsed_value
+        smallest_digit = np.floor(np.log10(span)) - 3
 
-            if axis_type == "int":
-                smallest_digit = max(smallest_digit, 0)
+        if axis_type == "int":
+            smallest_digit = max(smallest_digit, 0)
 
-            precision = int(-smallest_digit) if smallest_digit < 0 else 0
+        precision = int(-smallest_digit) if smallest_digit < 0 else 0
 
-            return "{0:.{n}f}{1}".format(
-                parsed_value * data_to_display_scale, unit_suffix, n=precision
-            )
-        case _:
-            raise ValueError(f"Unknown axis type '{axis_type}'")
+        return "{0:.{n}f}{1}".format(
+            parsed_value * data_to_display_scale, unit_suffix, n=precision
+        )
+    else:
+        raise ValueError(f"Unknown axis type '{axis_type}'")
 
 
 def parse_coord_param_value(coord: float, param_schema: dict[str, Any]) -> Any:
@@ -537,26 +536,35 @@ def parse_coord_param_value(coord: float, param_schema: dict[str, Any]) -> Any:
     :param param_schema: The parameter schema for the axis.
     :return: The parsed parameter value.
     """
+
+    categories = get_param_categories(param_schema)
+
+    if categories:
+        category_idx = round(coord)
+        if not 0 <= category_idx < len(categories):
+            raise ValueError(f"No category corresponding to coordinate {coord}.")
+        return categories[category_idx]
+    else:
+        axis_type = param_schema.get("type", "float")
+        if axis_type == "int":
+            return int(round(coord))
+        elif axis_type == "float":
+            return coord
+        else:
+            raise ValueError(f"Unknown axis type '{axis_type}'")
+
+
+def get_param_categories(param_schema: dict[str, Any]) -> list[Any] | None:
+    """Return the categories for a parameter, if any.
+
+    :param param_schema: The parameter schema for the axis.
+    :return: A list of categories, or None if the parameter is not categorical.
+    """
     axis_type = param_schema.get("type", "float")
 
-    match axis_type:
-        case "bool":
-            if round(coord) not in [0, 1]:
-                raise ValueError(
-                    f"Coordinate {coord} categorisation as bool undefined."
-                )
-            return round(coord) == 1
-        case "enum":
-            members = list(param_schema.get("spec", {}).get("members", {}).values())
-            enum_idx = round(coord)
-            if not 0 <= enum_idx < len(list(members)):
-                raise ValueError(
-                    f"Coordinate {coord} categorisation as given enum undefined."
-                )
-            return members[enum_idx]
-        case "int":
-            return int(round(coord))
-        case "float":
-            return float(coord)
-        case _:
-            raise ValueError(f"Unknown axis type '{axis_type}'")
+    if axis_type == "bool":
+        return [False, True]
+    elif axis_type == "enum":
+        return list(param_schema.get("spec", {}).get("members", {}).values())
+    else:
+        return None

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -28,6 +28,7 @@ from .utils import (
     format_param_identity,
     get_axis_scaling_info,
     get_default_hidden_channels,
+    get_param_categories,
     group_axes_into_panes,
     group_channels_into_axes,
     hide_series_from_groups,
@@ -385,6 +386,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
             crosshair_labels = [x_label] + crosshair_labels
             crosshair = LabeledCrosshairCursor(self, pane, crosshair_labels)
             self.crosshairs.append(crosshair)
+            self._set_view_box_limits(pane.getViewBox())
 
         if len(self.panes) > 1:
             self.link_x_axes()
@@ -625,3 +627,10 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
         if not event.isAccepted():
             # Event not handled yet, so background/… was clicked instead of a point.
             self._background_clicked()
+
+    def _set_view_box_limits(self, view_box):
+        param_categories = get_param_categories(self.x_schema["param"])
+        if param_categories is not None:
+            x_min = -0.5
+            x_max = len(param_categories) - 0.5
+            view_box.setLimits(xMin=x_min, xMax=x_max, minXRange=1.05)


### PR DESCRIPTION
Fixes #506.

I've taken the liberty to cleanup the code a bit and make the cursor label consistent with the axis ticks (taking `.values()` of the `"members"` dict instead of `.keys()`. 

Also, since categorical data is only well-defined at the points where there is actually a tick, I've also added limits to the `view_box`es enclosing categorical scans preventing the user from scrolling out of range and ensuring there is at least always one valid category visible on the axis. Feel free to revert if you feel that's too restrictive for the user on the ux.