### PR TITLE
dashboard: Add time slider to scroll back through plot history

### DIFF
--- a/ndscan/plots/container_widgets.py
+++ b/ndscan/plots/container_widgets.py
@@ -107,8 +107,7 @@ class RootWidget(QtWidgets.QWidget):
 
         self.plot_widget: VerticalPanesWidget = None
 
-        if self.root.get_model() is not None:
-            self._change_model()
+        self._change_model(self.root.get_model())
 
     def get_title(self) -> str:
         return self.root.get_title()
@@ -122,7 +121,7 @@ class RootWidget(QtWidgets.QWidget):
             self.plot_widget.close()
         super().closeEvent(ev)
 
-    def _change_model(self):
+    def _change_model(self, model):
         if self.plot_widget is not None:
             self._show_message("No data.")
             self.widget_stack.removeWidget(self.plot_widget)
@@ -137,7 +136,6 @@ class RootWidget(QtWidgets.QWidget):
 
             self.plot_widget = None
 
-        model = self.root.get_model()
         if model is not None:
             self._show_message("Waiting for channel metadata for scan…")
 

--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -11,10 +11,15 @@ from .._qt import QtCore, QtGui
 from . import colormaps
 from .cursor import CrosshairAxisLabel, CrosshairLabel, LabeledCrosshairCursor
 from .model import ScanModel
+from .model.history import HistoryFromScanModel
 from .model.select_point import SelectPointFromScanModel
 from .model.slice import create_slice_roots
 from .model.subscan import create_subscan_roots
-from .plot_widgets import SliceableMenuPanesWidget, add_source_id_label
+from .plot_widgets import (
+    SliceableMenuPanesWidget,
+    add_source_id_label,
+    add_time_slider,
+)
 from .utils import (
     CONTRASTING_COLOR_TO_HIGHLIGHT,
     HIGHLIGHT_PEN,
@@ -282,6 +287,16 @@ class _ImagePlot:
                 self.averages_by_coords[coords][0] if averaging_enabled else z
             )
 
+        # Remove any old points that have now been deleted
+        if num_to_show < self.num_shown:
+            all_x_inds = _coords_to_indices(x_data[:num_to_show], self.x_range)
+            all_y_inds = _coords_to_indices(y_data[:num_to_show], self.y_range)
+
+            removal_mask = np.full(self.image_data.shape, True)
+            removal_mask[all_x_inds, all_y_inds] = False
+
+            self.image_data[removal_mask] = np.nan
+
         cmap = colormaps.plasma
         channel = self.channels[self.active_channel_name]
         display_hints = channel.get("display_hints", {})
@@ -312,13 +327,17 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
     def __init__(self, model: ScanModel):
         super().__init__()
 
-        self.model = model
+        self.base_model = model
+        self.model = HistoryFromScanModel(model)
 
         self.model.channel_schemata_changed.connect(self._initialise_series)
         self.model.points_appended.connect(lambda p: self._update_points(p, False))
         self.model.points_rewritten.connect(lambda p: self._update_points(p, True))
 
         self.selected_point_model = SelectPointFromScanModel(self.model)
+        self.selected_point_model.source_index_changed.connect(
+            self._set_highlighted_index
+        )
 
         self.data_names = []
 
@@ -329,6 +348,7 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
         self.plot: _ImagePlot | None = None
         self.crosshair = None
         self._highlighted_xy = (None, None)
+        self.time_slider = None
 
         self.found_duplicate_coords = False
         self.unique_coords = set[tuple[float, float]]()
@@ -420,6 +440,9 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
 
         self.subscan_roots = create_subscan_roots(self.selected_point_model)
         self.slice_roots = create_slice_roots(self.model, self.selected_point_model)
+
+        if self.time_slider is None and self.base_model.has_independent_history:
+            self.add_time_slider()
 
         self.ready.emit()
 
@@ -528,8 +551,7 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
         y = self.plot.y_range[0] + y_idx * self.plot.y_range[2]
 
         source_idx = self._xy_to_source_index(x, y)
-        if source_idx is not None:
-            self._highlight_point_at_index(source_idx)
+        self.selected_point_model.set_source_index(source_idx)
 
     def keyPressEvent(self, event):
         """Handle arrow key presses to move the highlighted point."""
@@ -549,12 +571,11 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
         step = -1 if is_left or is_down else 1
         neighbour_idx = self._get_highlighted_neighbour_index(axis, step)
         if neighbour_idx is not None:
-            self._highlight_point_at_index(neighbour_idx)
+            self.selected_point_model.set_source_index(neighbour_idx)
         event.accept()
 
-    def _highlight_point_at_index(self, source_idx: int | None):
+    def _set_highlighted_index(self, source_idx: int | None):
         """Highlight the point at the given index of the source data."""
-        self.selected_point_model.set_source_index(source_idx)
 
         if source_idx is None:
             self._highlighted_xy = (None, None)
@@ -654,3 +675,27 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
             }
 
         view_box.setLimits(**kwargs)
+
+    def add_time_slider(self):
+        self.time_slider = add_time_slider(self.layout, self.scene(), self.model)
+        self.time_slider.cutoff_changed.connect(self.time_cutoff_changed)
+
+    def time_cutoff_changed(self, cutoff: int):
+        if cutoff == -1:
+            return
+
+        # Check if previously highlighted point should still exist
+        highlighted_idx = self.selected_point_model.get_source_index()
+
+        if highlighted_idx is not None and highlighted_idx > cutoff:
+            self._set_highlighted_index(None)
+
+    def focusInEvent(self, event):
+        if self.time_slider is not None:
+            self.time_slider.show()
+        super().focusInEvent(event)
+
+    def focusOutEvent(self, event):
+        if self.time_slider is not None:
+            self.time_slider.hide()
+        super().focusOutEvent(event)

--- a/ndscan/plots/model/__init__.py
+++ b/ndscan/plots/model/__init__.py
@@ -174,6 +174,8 @@ class ScanModel(Model):
     points_appended = QtCore.pyqtSignal(dict)
     annotations_changed = QtCore.pyqtSignal(list)
 
+    has_independent_history = True
+
     def __init__(
         self, axes: list[dict[str, Any]], schema_revision: int, context: Context
     ):

--- a/ndscan/plots/model/history.py
+++ b/ndscan/plots/model/history.py
@@ -1,0 +1,130 @@
+import logging
+from typing import Any
+
+import numpy as np
+
+from . import ScanModel
+
+logger = logging.getLogger(__name__)
+
+
+class HistoryFromScanModel(ScanModel):
+    """Restricts a given base model to a given number of points (`cutoff`) in
+    acquisition order, hence reproducing the state at a prior point.
+
+    Annotations are passed through, without storing/replaying changes.
+
+    Point content changes are forwarded, but the schema is static; changes to the latter
+    necessitate a new model instance.
+    """
+
+    def __init__(
+        self,
+        parent: ScanModel,
+        cutoff: int = -1,
+    ):
+        """
+        Model describing a prior state of a `ScanModel`
+
+        :param parent: The parent scan model.
+        :param cutoff: State to roll back to. This is either the index of the entry
+            to roll back to, or -1 for following the latest state as new points come in.
+        """
+        self.parent = parent
+        super().__init__(self.parent.axes, parent.schema_revision, parent.context)
+
+        self._sliced_data = {}
+
+        self.parent.channel_schemata_changed.connect(self.channel_schemata_changed)
+        self.parent.points_appended.connect(self._append_data)
+        self.parent.points_rewritten.connect(self._rewrite_data)
+        self.parent.annotations_changed.connect(self._update_annotations)
+
+        self._cutoff = cutoff
+        self._rewrite_data()
+
+        self._update_annotations(self.parent._annotations)
+
+    def _update_annotations(self, annotations):
+        self._annotation_schemata = self.parent._annotation_schemata
+        self._annotations = annotations
+        self.annotations_changed.emit(annotations)
+
+    def update_cutoff(self, cutoff: int) -> None:
+        parent_data = self.parent.get_point_data()
+
+        num_points = len(next(iter(parent_data.values()), []))
+
+        if cutoff == -1 or num_points == 0:
+            sliced_data = parent_data
+        elif 0 <= cutoff < num_points:
+            sliced_data = self.slice_data(parent_data, cutoff)
+        else:
+            raise ValueError(
+                f"Cannot rollback to index {cutoff} "
+                f"(have only {num_points} points available)"
+            )
+        self._cutoff = cutoff
+
+        data_rewritten = False
+        for name, incoming_values in sliced_data.items():
+            # Check if points were appended or rewritten.
+            if name in self._sliced_data:
+                imax = min(len(incoming_values), len(self._sliced_data[name]))
+                if not np.array_equal(
+                    incoming_values[:imax], self._sliced_data[name][:imax]
+                ):
+                    data_rewritten = True
+
+        self._sliced_data = sliced_data
+
+        if data_rewritten:
+            self.points_rewritten.emit(self._sliced_data)
+        else:
+            self.points_appended.emit(self._sliced_data)
+
+    def _rewrite_data(self, *args) -> None:
+        point_data = self.parent.get_point_data()
+        num_points = len(next(iter(point_data.values()), []))
+
+        if self._cutoff >= num_points:
+            self.update_cutoff(-1)
+
+        self.update_cutoff(self._cutoff)
+
+    def _append_data(self, *args) -> None:
+        point_data = self.parent.get_point_data()
+        num_points = len(next(iter(point_data.values()), []))
+
+        if self._cutoff >= num_points:
+            self.update_cutoff(-1)
+
+        if self._cutoff == -1:
+            self.update_cutoff(self._cutoff)
+
+    def slice_data(
+        self,
+        source_data: dict[str, Any],
+        cutoff: int,
+    ) -> dict[str, Any]:
+        """Extract the sliced data from the parent point data.
+
+        :param source_data: The point data from the parent model.
+        :param cutoff: The index of the target to which to slice up to.
+        :return: The sliced point data.
+        """
+        return {axis: values[: cutoff + 1] for axis, values in source_data.items()}
+
+    def get_channel_schemata(self) -> dict[str, Any]:
+        return self.parent.get_channel_schemata()
+
+    def get_point_data(self) -> dict[str, Any]:
+        return self._sliced_data
+
+    def quit(self) -> None:
+        self.parent.points_appended.disconnect(self._append_data)
+        self.parent.points_rewritten.disconnect(self._rewrite_data)
+        self.parent.annotations_changed.disconnect(self._update_annotations)
+        self.parent.channel_schemata_changed.disconnect(
+            self._on_channel_schemata_changed
+        )

--- a/ndscan/plots/model/select_point.py
+++ b/ndscan/plots/model/select_point.py
@@ -2,11 +2,14 @@ from typing import Any
 
 import numpy
 
+from ..._qt import QtCore
 from ...utils import strip_prefix
 from . import ScanModel, SinglePointModel
 
 
 class SelectPointFromScanModel(SinglePointModel):
+    source_index_changed = QtCore.pyqtSignal(object)
+
     def __init__(self, source: ScanModel):
         super().__init__(source.schema_revision, source.context)
         self._source = source
@@ -61,6 +64,7 @@ class SelectPointFromScanModel(SinglePointModel):
             return
         self._point = point
         self.point_changed.emit(point)
+        self.source_index_changed.emit(idx)
 
 
 def _all_array_equal(left, right):

--- a/ndscan/plots/model/slice.py
+++ b/ndscan/plots/model/slice.py
@@ -115,6 +115,8 @@ class SliceForScanModel(ScanModel):
     necessitate a new model instance.
     """
 
+    has_independent_history = False
+
     def __init__(
         self,
         parent: ScanModel,
@@ -148,6 +150,19 @@ class SliceForScanModel(ScanModel):
     def _update(self, *_args) -> None:
         parent_data = self._parent.get_point_data()
         fixed_point_idx = self._fixed_point.get_source_index()
+
+        if fixed_point_idx is None:
+            return
+
+        # De-select point if it has been removed
+        # FIXME: This should ideally be handled by the widget handling the selection
+        # of the `fixed_point`, but we must do this after the parent model to decide
+        # which points to remove, where it then emits the signal this slot attaches to
+        num_points = len(parent_data.get("axis_0", []))
+        if fixed_point_idx >= num_points:
+            self._fixed_point.set_source_index(None)
+            return
+
         sliced_data = self.slice_data(parent_data, fixed_point_idx)
 
         data_rewritten = False

--- a/ndscan/plots/model/slice.py
+++ b/ndscan/plots/model/slice.py
@@ -43,8 +43,7 @@ class SliceRoot(Root):
         if fixed_point_idx is None:
             if self._model:
                 self._model.quit()
-                self.model_changed.emit(None)
-            self._model = None
+            self.detach_model()
             return
 
         if self._model is None:
@@ -52,6 +51,11 @@ class SliceRoot(Root):
                 self._parent, self.axis_idx, self._selected_point
             )
             self.model_changed.emit(self._model)
+
+    def detach_model(self):
+        if self._model is not None:
+            self._model = None
+            self.model_changed.emit(None)
 
     def get_model(self) -> Model | None:
         return self._model

--- a/ndscan/plots/plot_widgets.py
+++ b/ndscan/plots/plot_widgets.py
@@ -14,6 +14,8 @@ import pyqtgraph.exporters
 
 from .._qt import QtCore, QtGui, QtWidgets
 from .model import Context, Root
+from .model.history import HistoryFromScanModel
+from .time_slider import TimeSlider, TimeSliderContainer
 
 logger = logging.getLogger(__name__)
 
@@ -487,6 +489,39 @@ class SliceableMenuPanesWidget(SubplotMenuPanesWidget):
         # which in causes the dock to be removed.
         self.slice_plots[name].close()
         self.setFocus()
+
+
+def add_time_slider(
+    layout: QtWidgets.QGraphicsLayout,
+    scene: QtWidgets.QGraphicsScene,
+    model: HistoryFromScanModel,
+) -> TimeSlider:
+    """
+    Add a `TimeSliderContainer` at the bottom of the `layout` provided to allow
+    scrubbing over point acquisition history described by `model`.
+    """
+    container = TimeSliderContainer()
+    time_slider = container.slider
+    time_slider.setSizePolicy(
+        QtWidgets.QSizePolicy.Policy.Expanding,
+        QtWidgets.QSizePolicy.Policy.Fixed,
+    )
+
+    time_slider_proxy = scene.addWidget(container)
+    layout.addItem(
+        time_slider_proxy,
+        layout.rowCount(),
+        0,
+        QtCore.Qt.AlignmentFlag.AlignBaseline | QtCore.Qt.AlignmentFlag.AlignJustify,
+    )
+
+    time_slider.update_points(model.get_point_data())
+    time_slider.cutoff_changed.connect(model.update_cutoff)
+
+    model.parent.points_appended.connect(time_slider.update_points)
+    model.parent.points_rewritten.connect(time_slider.update_points)
+
+    return time_slider
 
 
 def add_source_id_label(

--- a/ndscan/plots/time_slider.py
+++ b/ndscan/plots/time_slider.py
@@ -1,0 +1,89 @@
+from .._qt import QtCore, QtWidgets
+from .utils import TIME_SLIDER_COLOR
+
+
+class TimeSliderContainer(QtWidgets.QWidget):
+    def __init__(self, container_height=10):
+        super().__init__()
+        self.slider = TimeSlider(self)
+
+        self.setFixedHeight(container_height)
+        self.slider._container_height = container_height
+        self.setStyleSheet("background: transparent")
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        new_width = event.size().width()
+        self.slider.setExpanded(False, new_width)
+
+
+class TimeSlider(QtWidgets.QSlider):
+    cutoff_changed = QtCore.pyqtSignal(int)
+
+    def __init__(
+        self,
+        parent=None,
+        expanded_height: int = 6,
+        collapsed_height: int = 2,
+        container_height: int = 10,
+    ):
+        super().__init__(QtCore.Qt.Orientation.Horizontal, parent)
+
+        self._container_height = container_height
+        self.expanded_height = expanded_height
+        self.collapsed_height = collapsed_height
+
+        self.valueChanged.connect(self.rollback_target)
+
+        self.setTickInterval(1)
+        self.setMinimum(0)
+        self.setValue(self.maximum())
+
+        self._set_stylesheet()
+
+    def update_points(self, point_data: dict[str, list]):
+        num_points = len(next(iter(point_data.values()), []))
+        self.setMaximum(max(0, num_points - 1))
+
+        if self.target_idx == -1:
+            self.setValue(self.maximum())
+
+    def rollback_target(self, index):
+        if index == self.maximum():
+            self.target_idx = -1
+        else:
+            self.target_idx = index
+
+        self.cutoff_changed.emit(self.target_idx)
+
+    def _set_stylesheet(self):
+        self.setStyleSheet(f"""
+            QSlider::add-page:horizontal {{
+            background: rgba(0, 0, 0, 200);
+            }}
+            QSlider::handle:horizontal {{
+            background: transparent;
+                border: none;
+            }}
+            QSlider::sub-page:horizontal {{
+                background: {TIME_SLIDER_COLOR};
+            }}
+            QSlider::handle:horizontal::hover {{
+            background: #fff;
+                border-radius: 3px;
+            }}
+        """)
+
+    def setExpanded(self, expanded: bool, width):
+        height = self.expanded_height if expanded else self.collapsed_height
+        y_pos = self._container_height - height
+
+        self.setGeometry(0, y_pos, width, self.expanded_height)
+
+    def enterEvent(self, event):
+        self.setExpanded(True, self.parent().width())
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self.setExpanded(False, self.parent().width())
+        super().leaveEvent(event)

--- a/ndscan/plots/utils.py
+++ b/ndscan/plots/utils.py
@@ -30,6 +30,7 @@ FIT_COLORS = [
 #: pyqtgraph mkPen spec for highlighting selected points.
 HIGHLIGHT_PEN = {"color": "#ffff00", "width": 5}
 CONTRASTING_COLOR_TO_HIGHLIGHT = "#c61187ff"
+TIME_SLIDER_COLOR = "#a1d4e6"
 
 
 def _get_priority(channel_metadata: dict[str, Any]):

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -9,11 +9,13 @@ from .._qt import QtCore
 from .annotation_items import ComputedCurveItem, CurveItem, VLineItem
 from .cursor import CrosshairAxisLabel, LabeledCrosshairCursor
 from .model import ScanModel
+from .model.history import HistoryFromScanModel
 from .model.select_point import SelectPointFromScanModel
 from .model.subscan import create_subscan_roots
 from .plot_widgets import (
     SubplotMenuPanesWidget,
     add_source_id_label,
+    add_time_slider,
     build_channel_selection_context_menu,
 )
 from .utils import (
@@ -250,7 +252,8 @@ class _XYSeries(QtCore.QObject):
 class XY1DPlotWidget(SubplotMenuPanesWidget):
     def __init__(self, model: ScanModel):
         super().__init__()
-        self.model = model
+        self.base_model = model
+        self.model = HistoryFromScanModel(model)
 
         # Since we are a QObject ourselves, and the parents will make sure the widget is
         # deleteLater()d on the on the C++ side once it is removed from the UI, we can
@@ -278,6 +281,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
 
         self.crosshairs = []
         self._highlighted_spot = None
+        self.time_slider = None
 
         # List of all scalar channel names for the context menu.
         self.data_names = None
@@ -405,6 +409,9 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
                 )
             ],
         )
+
+        if self.time_slider is None and self.base_model.has_independent_history:
+            self.add_time_slider()
 
         # Make sure we put back annotations (if they haven't changed but the points
         # have been rewritten, there might not be an annotations_changed event).
@@ -634,3 +641,27 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
             x_min = -0.5
             x_max = len(param_categories) - 0.5
             view_box.setLimits(xMin=x_min, xMax=x_max, minXRange=1.05)
+
+    def add_time_slider(self):
+        self.time_slider = add_time_slider(self.layout, self.scene(), self.model)
+        self.time_slider.cutoff_changed.connect(self.time_cutoff_changed)
+
+    def focusInEvent(self, event):
+        if self.time_slider is not None:
+            self.time_slider.show()
+        super().focusInEvent(event)
+
+    def focusOutEvent(self, event):
+        if self.time_slider is not None:
+            self.time_slider.hide()
+        super().focusOutEvent(event)
+
+    def time_cutoff_changed(self, state: int):
+        if state == -1:
+            return
+
+        # Check if previously highlighted point still exists
+        highlighted_idx = self.selected_point_model.get_source_index()
+
+        if highlighted_idx is not None and highlighted_idx > state:
+            self._set_highlighted_index(None)


### PR DESCRIPTION
Adds a slider at the bottom of the widget to rollback through the point acquisition history in the order in which they came in -- useful e.g. for debugging if something in the experiment drifts.

The annotations are always the latest available from all points, and does not roll back, at least as currently implemented.

Open to suggestions for improving the UX / colour schemes etc. 
Should we e.g. hide the slider until explicitly enabled from a context menu?

This was originally motivated by MM saying she wanted to add progress bars for scans with deterministic number of points. I figured this could be cleanly done by a thin line going along the bottom of the screen, and would also be good to double as a time slider -- I've implemented only the latter here. 

Demo:

https://github.com/user-attachments/assets/b7c20e26-f652-4e6b-b92a-4a5ba36d5065


