### PR TITLE
plots: Only hide time slider on focusOut when at default (all points)

### DIFF
--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -696,6 +696,6 @@ class Image2DPlotWidget(SliceableMenuPanesWidget):
         super().focusInEvent(event)
 
     def focusOutEvent(self, event):
-        if self.time_slider is not None:
+        if self.time_slider is not None and self.time_slider.is_following_latest():
             self.time_slider.hide()
         super().focusOutEvent(event)

--- a/ndscan/plots/time_slider.py
+++ b/ndscan/plots/time_slider.py
@@ -41,15 +41,23 @@ class TimeSlider(QtWidgets.QSlider):
 
         self._set_stylesheet()
 
+    def is_following_latest(self):
+        """Return whether the slider is at its maximum, where it has the meaning of
+        following points as they come in (cutoff -1).
+        """
+        return self.target_idx == -1
+
     def update_points(self, point_data: dict[str, list]):
         num_points = len(next(iter(point_data.values()), []))
         self.setMaximum(max(0, num_points - 1))
 
-        if self.target_idx == -1:
+        if self.is_following_latest():
             self.setValue(self.maximum())
 
     def rollback_target(self, index):
         if index == self.maximum():
+            # When scrubbing all the way to the right, switch to the "sticky" following
+            # mode.
             self.target_idx = -1
         else:
             self.target_idx = index

--- a/ndscan/plots/xy_1d.py
+++ b/ndscan/plots/xy_1d.py
@@ -652,7 +652,7 @@ class XY1DPlotWidget(SubplotMenuPanesWidget):
         super().focusInEvent(event)
 
     def focusOutEvent(self, event):
-        if self.time_slider is not None:
+        if self.time_slider is not None and self.time_slider.is_following_latest():
             self.time_slider.hide()
         super().focusOutEvent(event)
 


### PR DESCRIPTION
This way, the user still gets visual feedback when newer points are
being discarded, but the UI isn't cluttered in the default case.
